### PR TITLE
fix: use env variable for version

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -220,6 +220,9 @@ module.exports = function(grunt) {
             defaultConfig = configFile;
             packageFile = require('./' + defaultConfig);
 
+            packageFile.version = (process.env['PRODUCT_VERSION'] || packageFile.version);
+
+
             if (packageFile) {
                 grunt.log.ok(appName + ' config loaded successfully'.green);
 


### PR DESCRIPTION
This makes it easier to build a version of the web-apps that matches the server version which otherwise will show an error due to a version mismatch

Upstream build tooling uses this variable for other cases but I cannot find where it would be set for the web-apps build otherwise.
