### PR TITLE
Add joint grunt less command

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -891,6 +891,16 @@ module.exports = function(grunt) {
     grunt.registerTask('deploy-testpresentationeditor', ['init-build-testpresentationeditor', 'deploy-app']);
     grunt.registerTask('deploy-testspreadsheeteditor', ['init-build-testspreadsheeteditor', 'deploy-app']);
 
+    // Build LESS only for all editors
+    grunt.registerTask('less-all', [
+        'init-build-common', 'main-app-init', 'less',
+        'init-build-documenteditor', 'main-app-init', 'less',
+        'init-build-spreadsheeteditor', 'main-app-init', 'less',
+        'init-build-presentationeditor', 'main-app-init', 'less',
+        'init-build-pdfeditor', 'main-app-init', 'less',
+        'init-build-visioeditor', 'main-app-init', 'less'
+    ]);
+
     grunt.registerTask('default', ['deploy-common-component',
                                    'deploy-documenteditor-component',
                                    'deploy-spreadsheeteditor-component',

--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -320,6 +320,11 @@ module.exports = function(grunt) {
                     files: packageFile['apps-common']['imagemin']['images-common']
                 }
             },
+            copy: {
+                'images-app': {
+                    files: packageFile['apps-common']['imagemin']['images-common']
+                }
+            },
             svgmin: {
                 options: {...svgmin_opts},
                 dist: {
@@ -471,6 +476,9 @@ module.exports = function(grunt) {
                 },
                 indexhtml: {
                     files: packageFile['main']['copy']['indexhtml']
+                },
+                'images-app': {
+                    files: packageFile['main']['imagemin']['images-app']
                 }
             },
 
@@ -810,7 +818,7 @@ module.exports = function(grunt) {
 
     //quick workaround for build desktop version
     var copyTask = grunt.option('desktop')? "copy": "copy:script";
-    var imageminTask = grunt.option('skip-imagemin') ? [] : ['imagemin'];
+    var imageminTask = grunt.option('skip-imagemin') ? ['copy:images-app'] : ['imagemin'];
 
     grunt.registerTask('deploy-api',                    ['api-init', 'clean', copyTask, 'replace:writeVersion']);
     grunt.registerTask('deploy-apps-common',            ['apps-common-init', 'clean', 'copy', 'inline', ...imageminTask, 'svgmin']);


### PR DESCRIPTION
Currently to build LESS, we need to either run LESS commands separately, or the main build.

This adds `less-all`. Meaning you can do:

` docker compose exec eo bash -c "cd /var/www/onlyoffice/web-apps-develop/build && grunt less-all"`

It does build on: https://github.com/Euro-Office/web-apps/pull/5

So that needs to be merged first, or just merge this and close the other.

See comments here: https://github.com/Euro-Office/fork/issues/23 For details. This content also needs adding to the fork build README.