### PR TITLE
fix: Properly copy over common files

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -368,6 +368,7 @@ module.exports = function(grunt) {
                 }
             },
             copy: {
+                ...packageFile['apps-common'].copy,
                 'images-app': {
                     files: packageFile['apps-common']['imagemin']['images-common']
                 }


### PR DESCRIPTION
Caused by 91ef4ddda83a163fb705bfe8e782790624f1e0fe some files that are defined in https://github.com/Euro-Office/web-apps/blob/34a00d86bc07fd59eb21addf882b5749c434120c/build/common.json#L87 were not copied over during build anymore. 

Fix https://github.com/Euro-Office/fork/issues/74


Also the browser console no longer complains about those files failing to load