### PR TITLE
docs: add integration roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,54 @@
+<!--
+SPDX-FileCopyrightText: 2026 Euro-Office contributors
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Euro-Office Integration Roadmap
+
+> This roadmap covers the integration of Euro-Office DocumentServer with external platforms (OpenCloud, SOGo, Open-Xchange, Zimbra) via WOPI and Docs API protocols.
+>
+> Full integration planning document: [.github/INTEGRATION-PLANNING.md](https://github.com/Euro-Office/DocumentServer/blob/main/.github/INTEGRATION-PLANNING.md)
+
+## Role in Integration
+
+This repo provides the **editor UI** (HTML/CSS/JS frontend) that renders inside the iframe. It handles toolbar rendering, plugin injection, branding, and the user-facing editing experience.
+
+## Roadmap Items
+
+### Phase 1 — Foundation
+
+- [ ] Verify editor UI renders correctly when embedded via iframe from external platforms
+- [ ] Test toolbar customization options available through Docs API config
+- [ ] Validate plugin injection mechanism works for platform-specific plugins
+- [ ] Ensure branding customization (logo, colors, links) works via config
+
+### Shared Requirements (this repo)
+
+- [ ] **Branding** — Platform-specific branding via Docs API configuration
+- [ ] **Plugin system** — Plugin injection for platform-specific extensions
+
+---
+
+## Cross-Repo References
+
+| Repo | Role |
+|------|------|
+| [server](https://github.com/Euro-Office/server) | WOPI endpoints, discovery, proof keys, JWT, admin panel |
+| [sdkjs](https://github.com/Euro-Office/sdkjs) | Docs API, editor engine, co-editing, format conversion |
+| [web-apps](https://github.com/Euro-Office/web-apps) | Editor UI, toolbar, plugins, branding |
+| [core](https://github.com/Euro-Office/core) | File format conversion engine (OOXML, ODF, PDF) |
+| [eurooffice-nextcloud](https://github.com/Euro-Office/eurooffice-nextcloud) | OpenCloud/Nextcloud WOPI connector |
+| [DocumentServer](https://github.com/Euro-Office/DocumentServer) | Integration orchestration, Docker, Helm |
+| [document-server-integration](https://github.com/Euro-Office/document-server-integration) | Integration examples & API docs |
+| [document-server-package](https://github.com/Euro-Office/document-server-package) | DEB/RPM/Helm packaging |
+| [docker-ci](https://github.com/Euro-Office/docker-ci) | Docker images for deployment |
+| [desktop-sdk](https://github.com/Euro-Office/desktop-sdk) | Desktop CEF integration |
+| [desktop-apps](https://github.com/Euro-Office/desktop-apps) | Desktop packaging & Electron wrappers |
+
+## Protocol Documentation
+
+- [WOPI Protocol Overview — Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/)
+- [WOPI Overview — ONLYOFFICE API](https://api.onlyoffice.com/docs/docs-api/using-wopi/overview/)
+- [WOPI REST API — ONLYOFFICE API](https://api.onlyoffice.com/docs/docs-api/using-wopi/wopi-rest-api/)
+- [WOPI Discovery — ONLYOFFICE API](https://api.onlyoffice.com/docs/docs-api/using-wopi/wopi-discovery/)
+- [Docs API Basic Concepts — ONLYOFFICE API](https://api.onlyoffice.com/docs/docs-api/get-started/basic-concepts/)


### PR DESCRIPTION
## Summary

- Add repo-specific `ROADMAP.md` covering editor UI integration items: iframe embedding, toolbar customization, plugin injection, branding via Docs API config
- Part of the Euro-Office platform integration roadmap (WOPI + Docs API for OpenCloud, Zimbra, SOGo, Open-Xchange)

Full integration planning: [INTEGRATION-PLANNING.md](https://github.com/Euro-Office/DocumentServer/blob/main/.github/INTEGRATION-PLANNING.md)