### PR TITLE
fix: prevent undefined BUILD_NUMBER from triggering mobile dev mode

### DIFF
--- a/vendor/framework7-react/build/webpack.config.js
+++ b/vendor/framework7-react/build/webpack.config.js
@@ -217,7 +217,7 @@ const config = {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(env),
       'process.env.TARGET': JSON.stringify(target),
-      __PRODUCT_VERSION__: JSON.stringify(process.env.PRODUCT_VERSION ? `${process.env.PRODUCT_VERSION}.${process.env.BUILD_NUMBER}` : '6.2.0.123d'),
+      __PRODUCT_VERSION__: JSON.stringify(process.env.PRODUCT_VERSION ? (process.env.BUILD_NUMBER ? `${process.env.PRODUCT_VERSION}.${process.env.BUILD_NUMBER}` : process.env.PRODUCT_VERSION) : '6.2.0.123d'),
       ...themeDefines(),
     }),
     new webpack.BannerPlugin(`\n* Version: ${process.env.PRODUCT_VERSION} (build: ${process.env.BUILD_NUMBER})\n`),


### PR DESCRIPTION
## Summary

- When `PRODUCT_VERSION` is set but `BUILD_NUMBER` is not (as in the Docker build), the webpack config produced `"9.2.1.undefined"` as the version string
- The trailing `d` in `undefined` matched the `/(?:d|debug)$/` regex in `developVersion()`, causing the mobile editor to try loading non-existent dev SDK files (`sdkjs/develop/sdkjs/word/scripts.js`), resulting in a 404
- Only append `.BUILD_NUMBER` to the version string when `BUILD_NUMBER` is actually defined