### PR TITLE
feat: add Ctrl+Alt+H keyboard shortcut to toggle highlight color

### DIFF
--- a/apps/documenteditor/main/app/controller/Toolbar.js
+++ b/apps/documenteditor/main/app/controller/Toolbar.js
@@ -374,6 +374,22 @@ define([
             toolbar.mnuMultiChangeLevel.menu.on('show:after',           _.bind(this.onChangeLevelShowAfter, this, 2));
             toolbar.mnuMultiChangeLevel.menu.on('item:click',           _.bind(this.onChangeLevelClick, this, 2));
             toolbar.btnHighlightColor.on('click',                       _.bind(this.onBtnHighlightColor, this));
+            (function(me) {
+                var highlightKeymap = {};
+                highlightKeymap['ctrl+alt+h'] = function() {
+                    var currentColor = toolbar.btnHighlightColor.currentColor;
+                    var textProps = me.api.get_TextProps();
+                    var hl = textProps && textProps.get_TextPr && textProps.get_TextPr().get_HighLight();
+                    var selColor = (hl && hl !== -1 && hl.get_hex) ? hl.get_hex().toUpperCase() : null;
+                    if (selColor && typeof currentColor === 'string' && selColor === currentColor.toUpperCase()) {
+                        me._setMarkerColor('transparent');
+                    } else {
+                        me._setMarkerColor(currentColor);
+                    }
+                    return false;
+                };
+                Common.util.Shortcuts.delegateShortcuts({shortcuts: highlightKeymap});
+            })(this);
             toolbar.btnFontColor.on('click',                            _.bind(this.onBtnFontColor, this));
             toolbar.btnFontColor.on('color:select',                     _.bind(this.onSelectFontColor, this));
             toolbar.btnFontColor.on('auto:select',                      _.bind(this.onAutoFontColor, this));


### PR DESCRIPTION
## Summary

- Adds `Ctrl+Alt+H` shortcut to the document editor toolbar
- First press applies the current highlight color to selected text
- Second press removes the highlight if the selection's color matches the current highlight color

## How it works

Reads the highlight state directly from `api.get_TextProps()` on each keypress rather than relying on cached button state. Uses `_setMarkerColor('transparent')` (which calls `SetMarkerFormat(true, false)`) to remove the highlight — not `SetMarkerFormat(false)` which only exits painting mode without removing existing highlights.

## Test plan

- [ ] Select text → `Ctrl+Alt+H` → text highlighted in yellow
- [ ] With highlighted text selected → `Ctrl+Alt+H` → highlight removed
- [ ] Change highlight color via toolbar → `Ctrl+Alt+H` → applies new color
- [ ] No text selected → `Ctrl+Alt+H` → no crash

Fixes https://github.com/Euro-Office/DocumentServer/issues/55

🤖 Generated with [Claude Code](https://claude.com/claude-code)