### PR TITLE
Update Dockerfile to use relative paths for COPY commands

### DIFF
--- a/.docker/web-apps.bake.Dockerfile
+++ b/.docker/web-apps.bake.Dockerfile
@@ -21,16 +21,16 @@ FROM web-base AS web-apps
     ARG PRODUCT_VERSION
     ARG BUILD_ROOT=/package
 
-    COPY web-apps/build/package*.json /app/build/
-    COPY web-apps/build/sprites/package*.json /app/build/sprites/
-    COPY web-apps/build/plugins/grunt-inline/ /app/build/plugins/grunt-inline/
+    COPY build/package*.json /app/build/
+    COPY build/sprites/package*.json /app/build/sprites/
+    COPY build/plugins/grunt-inline/ /app/build/plugins/grunt-inline/
 
     RUN --mount=type=cache,target=/root/.npm \
         cd app/build && \
         npm install
 
 
-    COPY web-apps/ /app
+    COPY . /app
 
     ENV PRODUCT_VERSION=${PRODUCT_VERSION}
     ENV BUILD_ROOT=${BUILD_ROOT}


### PR DESCRIPTION
The docker image build fails due to non-existing paths.
After the change, the `docker build -t webapps -f .docker/web-apps.bake.Dockerfile` command works as expected.