### PR TITLE
fix: :bug: Fix operator precedence in About customer URL href

### DIFF
--- a/apps/common/mobile/lib/view/About.jsx
+++ b/apps/common/mobile/lib/view/About.jsx
@@ -81,8 +81,8 @@ const PageAbout = props => {
                             )}
                             {urlCustomer?.length && (
                                 <p className="about__text">
-                                    <Link id="settings-about-url" external={true} target="_blank" 
-                                        href={!/^https?:\/{2}/i.test(urlCustomer) ? "http:\/\/" : '' + urlCustomer}>
+                                    <Link id="settings-about-url" external={true} target="_blank"
+                                        href={(!/^https?:\/{2}/i.test(urlCustomer) ? 'http://' : '') + urlCustomer}>
                                         {urlCustomer}
                                     </Link>
                                 </p>


### PR DESCRIPTION
The ternary and string concatenation were not grouped correctly — due to operator precedence, the expression evaluated as:
  condition ? 'http://' : urlCustomer
instead of:
  (condition ? 'http://' : '') + urlCustomer

When urlCustomer had no scheme, href became 'http://' with the actual URL silently dropped. Affects all white-labelled installations supplying customization.customer.www without a protocol prefix.

## How to verify — logic level

  Paste into any browser DevTools console:

  ```js
  const buggy = url => !/^https?:\/{2}/i.test(url) ? "http://" : '' + url;
  const fixed = url => (!/^https?:\/{2}/i.test(url) ? 'http://' : '') + url;

  console.table([
      'example.com',
      'www.example.com',
      'https://example.com',
      'http://example.com',
      'HTTPS://example.com',
  ].map(input => ({ input, buggy: buggy(input), fixed: fixed(input) })));
  ```

  Expected output:

  | input                 | buggy                 | fixed                    |
  |-----------------------|-----------------------|--------------------------|
  | `example.com`         | `http://`             | `http://example.com`     |
  | `example.com`         | `http://`             | `http://example.com`     |
  | `www.example.com`     | `http://`             | `http://www.example.com` |
  | `https://example.com` | `https://example.com` | `https://example.com`    |
  | `http://example.com`  | `http://example.com`  | `http://example.com`     |
  | `HTTPS://example.com` | `HTTPS://example.com` | `HTTPS://example.com`    |

  Only inputs **without** an `http://` / `https://` scheme expose the bug. The
  last three rows confirm the fix doesn't regress URLs that previously worked.

  ## How to verify — UI

  Open the mobile editor with `customization.customer.www` set in the editor
  config. Navigate to **Settings → About** and inspect the customer URL link
  (`#settings-about-url`):

  ```html
  <!-- buggy build, customer.www = "example.com" -->
  <a id="settings-about-url" class="link external" href="http://" target="_blank">example.com</a>

  <!-- fixed build, customer.www = "example.com" -->
  <a id="settings-about-url" class="link external" href="http://example.com" target="_blank">example.com</a>
  ```

  The visible link text is identical in both builds — only `href` differs,
  which is why the bug is easy to miss in casual visual review.

  ### Screenshots (Pixel 5, dark theme)

  | Input | Before (buggy) | After (fixed) |
  |---|---|---|
  | `example.com` | ![buggy no-scheme](https://github.com/user-attachments/assets/9842cf67-9781-48a8-9b22-d088fd6f3c5d) | ![fixed no-scheme](https://github.com/user-attachments/assets/1994c9ec-165a-4531-9889-4ed0f5d2a91a) |
  | `www.example.com` | ![buggy no-scheme-www](https://github.com/user-attachments/assets/dd425008-4ede-43b2-a9eb-5250373d48a2) | ![fixed no-scheme-www](https://github.com/user-attachments/assets/eeb09729-53f0-4588-af9e-22c39cb81ece) |

  The red/green banner overlay at the top of each screenshot shows the actual
  `href` attribute on the rendered link — that's where the divergence lives.

  ## Test checklist

  - [ ] `customer.www = "example.com"` → link href = `http://example.com`, click opens the site
  - [ ] `customer.www = "www.example.com"` → link href = `http://www.example.com`, click opens the site
  - [ ] `customer.www = "http://example.com"` → link href unchanged, click opens the site
  - [ ] `customer.www = "https://example.com"` → link href unchanged, click opens the site
  - [ ] `customer.www = "HTTPS://example.com"` → link href unchanged (case-insensitive)
  - [ ] `customer.www` unset → link not rendered (existing `urlCustomer?.length` guard)