### PR TITLE
feat: :sparkles: Add ErrorBoundary on mobile

### DIFF
--- a/apps/common/mobile/lib/component/ErrorBoundary.jsx
+++ b/apps/common/mobile/lib/component/ErrorBoundary.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { f7 } from 'framework7-react';
+import i18next from 'i18next';
+
+class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError() {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error) {
+        const text = (error ? error.toString() : null) || this.props.message || i18next.t('Error.unknownErrorText');
+
+        const onClose = () => {
+            if (Common.Gateway?.requestClose) {
+                Common.Gateway.requestClose();
+            } else {
+                window.location.href = '/';
+            }
+        };
+
+        if (f7?.dialog) {
+            f7.dialog.create({
+                cssClass: 'error-dialog',
+                title: i18next.t('Error.criticalErrorTitle'),
+                text: `<div class="error-dialog__code">${text}</div>`,
+                buttons: [
+                    { text: i18next.t('Error.textOk'), onClick: onClose },
+                ],
+            }).open();
+        } else {
+            window.alert(text);
+            onClose();
+        }
+    }
+
+    render() {
+        if (this.state.hasError) return null;
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;

--- a/apps/common/mobile/resources/less/common.less
+++ b/apps/common/mobile/resources/less/common.less
@@ -1180,6 +1180,24 @@ input[type="number"]::-webkit-inner-spin-button {
 
 // Dialog with password
 .dialog {
+    &.error-dialog {
+        .error-dialog__code {
+            margin-top: 8px;
+            font-family: monospace;
+            font-size: 12px;
+            line-height: 1.5;
+            color: @text-error;
+            text-align: left;
+            overflow-wrap: break-word;
+            display: -webkit-box;
+            -webkit-line-clamp: 7;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-height: 120px;
+        }
+    }
+
     .modal-password {
         position: relative;
 
@@ -1239,6 +1257,7 @@ input[type="number"]::-webkit-inner-spin-button {
         color: @text-error;
     }
 }
+
 
 
 

--- a/apps/documenteditor/mobile/src/app.js
+++ b/apps/documenteditor/mobile/src/app.js
@@ -29,6 +29,7 @@ import App from './view/app.jsx';
 
 import { Provider } from 'mobx-react';
 import { stores } from './store/mainStore.js';
+import ErrorBoundary from '../../../common/mobile/lib/component/ErrorBoundary.jsx';
 // import { LocalStorage } from '../../../common/mobile/utils/LocalStorage';
 
 const container = document.getElementById('app');
@@ -40,13 +41,15 @@ const startApp = () => {
 
 // Mount React App
     root.render(
-        <I18nextProvider i18n={i18n}>
-            <Provider {...stores}>
-                {/*<Suspense fallback="loading...">*/}
-                <App />
-                {/*</Suspense>*/}
-            </Provider>
-        </I18nextProvider>
+        <ErrorBoundary>
+            <I18nextProvider i18n={i18n}>
+                <Provider {...stores}>
+                    {/*<Suspense fallback="loading...">*/}
+                    <App />
+                    {/*</Suspense>*/}
+                </Provider>
+            </I18nextProvider>
+        </ErrorBoundary>
     );
 };
 

--- a/apps/presentationeditor/mobile/src/app.js
+++ b/apps/presentationeditor/mobile/src/app.js
@@ -27,6 +27,7 @@ import i18n from './lib/i18n.js';
 
 import { Provider } from 'mobx-react';
 import { stores } from './store/mainStore.js';
+import ErrorBoundary from '../../../common/mobile/lib/component/ErrorBoundary.jsx';
 // import { LocalStorage } from '../../../common/mobile/utils/LocalStorage';
 
 const container = document.getElementById('app');
@@ -37,11 +38,13 @@ Framework7.use(Framework7React);
 
 // Mount React App
 root.render(
-    <I18nextProvider i18n={i18n}>
-        <Provider {...stores}>
-            {/*<Suspense fallback="loading...">*/}
-                <App />
-            {/*</Suspense>*/}
-        </Provider>
-    </I18nextProvider>
+    <ErrorBoundary>
+        <I18nextProvider i18n={i18n}>
+            <Provider {...stores}>
+                {/*<Suspense fallback="loading...">*/}
+                    <App />
+                {/*</Suspense>*/}
+            </Provider>
+        </I18nextProvider>
+    </ErrorBoundary>
 );

--- a/apps/spreadsheeteditor/mobile/src/app.js
+++ b/apps/spreadsheeteditor/mobile/src/app.js
@@ -28,6 +28,7 @@ import i18n from './lib/i18n.js';
 
 import { Provider } from 'mobx-react';
 import { stores } from './store/mainStore.js';
+import ErrorBoundary from '../../../common/mobile/lib/component/ErrorBoundary.jsx';
 // import { LocalStorage } from '../../../common/mobile/utils/LocalStorage.mjs';
 
 const container = document.getElementById('app');
@@ -38,11 +39,13 @@ Framework7.use(Framework7React);
 
 // Mount React App
 root.render(
-    <I18nextProvider i18n={i18n}>
-        <Provider {...stores}>
-            {/*<Suspense fallback="loading...">*/}
-                <App />
-            {/*</Suspense>*/}
-        </Provider>
-    </I18nextProvider>
+    <ErrorBoundary>
+        <I18nextProvider i18n={i18n}>
+            <Provider {...stores}>
+                {/*<Suspense fallback="loading...">*/}
+                    <App />
+                {/*</Suspense>*/}
+            </Provider>
+        </I18nextProvider>
+    </ErrorBoundary>
 );

--- a/apps/visioeditor/mobile/src/app.js
+++ b/apps/visioeditor/mobile/src/app.js
@@ -27,6 +27,7 @@ import i18n from './lib/i18n.js';
 
 import { Provider } from 'mobx-react';
 import { stores } from './store/mainStore.js';
+import ErrorBoundary from '../../../common/mobile/lib/component/ErrorBoundary.jsx';
 // import { LocalStorage } from '../../../common/mobile/utils/LocalStorage';
 
 const container = document.getElementById('app');
@@ -37,11 +38,13 @@ Framework7.use(Framework7React);
 
 // Mount React App
 root.render(
-    <I18nextProvider i18n={i18n}>
-        <Provider {...stores}>
-            {/*<Suspense fallback="loading...">*/}
-                <App />
-            {/*</Suspense>*/}
-        </Provider>
-    </I18nextProvider>
+    <ErrorBoundary>
+        <I18nextProvider i18n={i18n}>
+            <Provider {...stores}>
+                {/*<Suspense fallback="loading...">*/}
+                    <App />
+                {/*</Suspense>*/}
+            </Provider>
+        </I18nextProvider>
+    </ErrorBoundary>
 );


### PR DESCRIPTION
In editors display a framework7 dialog when ErrorBoundary catches a render error

## How to test

  > Open any document type (`.docx` / `.xlsx` / `.pptx` / `.vsdx`) in the
  > mobile editor

  ### Triggering a render error manually

  Real render crashes are not deterministic, so use DevTools to invoke the
  boundary's `componentDidCatch` directly.

  1. Open DevTools.
  2. In the Console tab, click the **top** dropdown at the top-left and
     switch context to the iframe whose URL ends in
     `/web-apps/apps/<editor>/mobile/index.html`.
  3. Paste and run:

     ```js
     (function triggerErrorBoundary() {
       const app = document.getElementById('app');
       const key = Object.keys(app).find(k => k.startsWith('__reactContainer'));
       const root = app[key].stateNode.current;
       const find = (f) => {
         if (!f) return null;
         const n = f.stateNode;
         if (n && typeof n.componentDidCatch === 'function'
             && typeof f.type?.getDerivedStateFromError === 'function') return n;
         return find(f.child) || find(f.sibling);
       };
       const eb = find(root);
       if (!eb) throw new Error('ErrorBoundary not found');
       eb.componentDidCatch(new Error('Manual ErrorBoundary test from DevTools'));
     })();
     ```

  The dialog should appear immediately. To test different error lengths,
  replace the message string — e.g. `new Error('Line1\nLine2\n…\nLine9')`
  to verify the multi-line truncation.

  ## Test plan

  ### Dialog appearance
  - [ ] A modal dialog appears with title **"Error"**
  - [ ] The error text is shown in monospace inside the dialog body
  - [ ] Exactly **one** button is rendered, labelled **"OK"**

  ### Dialog behaviour
  - [ ] Tap **OK**: the editor closes (in a hosted iframe, this calls
        `Common.Gateway.requestClose()`, so the parent app — e.g. Nextcloud —
        receives the close signal; outside that, it falls back to `/`)
  - [ ] The dialog cannot be dismissed by tapping outside (modal)

  ### Cross-editor coverage
  - [ ] documenteditor (`.docx`): dialog appears + single OK button works
  - [ ] spreadsheeteditor (`.xlsx`): same
  - [ ] presentationeditor (`.pptx`): same
  - [ ] visioeditor (`.vsdx`): same

  ### Cross-theme rendering (Framework7 `theme: 'auto'`)
  - [ ] **iOS** (UA = iPhone/iPad): centred title, rounded corners, OK
        centred below the body with a thin divider above it
  - [ ] **Android / Material** (UA = Pixel/other Android): left-aligned
        title, OK right-aligned in the dialog footer

  ### Color / contrast (light vs dark mode)
  - [ ] Light system theme: dialog body is light, error text is `#9b1c1c`
        (deep red) — passes WCAG AAA against white
  - [ ] Dark system theme: `body.theme-type-dark` is set; dialog body is
        dark, error text switches to `#ff6b6b` — passes WCAG AA against the
        dark dialog background
  - [ ] Toggle OS dark mode while the editor is open: on next dialog open,
        the text color matches the active theme

  ### Long error handling
  - [ ] Use a 9-line stack-trace payload (see the snippet note above)
  - [ ] Dialog body clamps to **7 lines** with `…` ellipsis
        (max-height 120 px)
  - [ ] Dialog does not grow to fill the screen

  ### Sanity
  - [ ] No console errors appear besides the simulated one
  - [ ] After tapping OK there are no stuck modals or stale React state

  ## Tested on
   - [ ] iOS Safari
      - [ ] documenteditor
      - [ ] spreadsheeteditor
      - [ ] presentationeditor
      - [ ] visioeditor
  - [ ] Android Chrome
      - [ ] documenteditor
      - [ ] spreadsheeteditor
      - [ ] presentationeditor
      - [ ] visioeditor


## Screenshots

  ### Dialog by platform — medium / long error in documenteditor

  | iOS | Android |
  |---|---|
  | ![ios-medium](https://github.com/user-attachments/assets/92f49f9b-122a-466e-afee-02e529980ccd) | ![android-medium](https://github.com/user-attachments/assets/1826c9dc-702e-4e03-b896-6f8335e44997) |
  | ![ios-long](https://github.com/user-attachments/assets/ef9b7ab9-8bbf-4fc6-83e1-db0c2d2c0b0b) | ![android-long](https://github.com/user-attachments/assets/8eaafa11-9330-4ca8-978a-7d46bd29a020) |

  ### Dialog across editor types

  | spreadsheeteditor | presentationeditor |
  |---|---|
  | ![cell](https://github.com/user-attachments/assets/6596b97a-aea8-41e5-976f-9a3861d936b5) | ![slide](https://github.com/user-attachments/assets/ef1b572f-9613-47d8-b83d-a6a31adff816) |