### PR TITLE
feat: hide mobile header logo via build-time theme override stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ apps/spreadsheeteditor/mobile/offlinedocs
 selenium-debug.log
 **/test/bin
 **/test/reports
+
+# generated at build time by theme.config.mjs
+apps/common/mobile/resources/less/_theme-mobile-overrides.less

--- a/apps/documenteditor/mobile/src/less/app.less
+++ b/apps/documenteditor/mobile/src/less/app.less
@@ -394,3 +394,5 @@
     margin-right: 5px;
 }
 
+@import '../../../../common/mobile/resources/less/_theme-mobile-overrides.less';
+

--- a/apps/presentationeditor/mobile/src/less/app.less
+++ b/apps/presentationeditor/mobile/src/less/app.less
@@ -177,8 +177,10 @@
 
 .bullet-menu-image ul{
     padding: 0;
-    
+
     li {
-        display: inherit; 
+        display: inherit;
     }
 }
+
+@import '../../../../common/mobile/resources/less/_theme-mobile-overrides.less';

--- a/apps/spreadsheeteditor/mobile/src/less/app.less
+++ b/apps/spreadsheeteditor/mobile/src/less/app.less
@@ -280,3 +280,5 @@
 .item-list.active .item-title {
     font-weight: 600;
 }
+
+@import '../../../../common/mobile/resources/less/_theme-mobile-overrides.less';

--- a/apps/visioeditor/mobile/src/less/app.less
+++ b/apps/visioeditor/mobile/src/less/app.less
@@ -100,3 +100,5 @@
     background: @black;
 }
 
+@import '../../../../common/mobile/resources/less/_theme-mobile-overrides.less';
+

--- a/build/theme.config.mjs
+++ b/build/theme.config.mjs
@@ -19,6 +19,16 @@ if (fs.existsSync(configPath)) {
   meta = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 }
 
+// Copy theme mobile overrides to a neutral stub path that all editor app.less files import.
+// Runs once at module load (before webpack starts). Generates an empty stub when the theme
+// has no mobile-overrides.less so the import in app.less always resolves.
+const overrideSrc = path.join(rootDir, 'theme', theme, 'assets', 'less', 'overrides', 'mobile-overrides.less');
+const overrideDst = path.join(rootDir, 'apps', 'common', 'mobile', 'resources', 'less', '_theme-mobile-overrides.less');
+try {
+  if (fs.existsSync(overrideSrc)) fs.copyFileSync(overrideSrc, overrideDst);
+  else fs.writeFileSync(overrideDst, '// no theme mobile overrides\n');
+} catch (e) { console.warn('[theme.config] mobile overrides copy failed:', e.message); }
+
 // Resolve a brand value with priority: env var > config.json > default.
 // Empty string in config.json is respected (explicit "hide this"), matching
 // build/Gruntfile.js _themVal semantics on the desktop side.

--- a/theme/euro-office/assets/less/overrides/mobile-overrides.less
+++ b/theme/euro-office/assets/less/overrides/mobile-overrides.less
@@ -1,0 +1,17 @@
+// --------------------------------------------------------------------------
+// Mobile Header Logo — hidden
+// The logo strip takes up 26px of navbar height. Collapsing all three rules
+// (the logo element, the navbar height, and the page offset) ensures no gap.
+// --------------------------------------------------------------------------
+
+.main-logo {
+    display: none;
+}
+
+.navbar.main-navbar.navbar-with-logo {
+    height: 0;
+}
+
+.page.page-with-subnavbar.page-with-logo .page-content {
+    --f7-page-subnavbar-offset: 0px;
+}


### PR DESCRIPTION
All four editor mobile app.less files now import a theme-agnostic stub (_theme-mobile-overrides.less) that is generated at build time by theme.config.mjs, which copies the active theme's mobile-overrides.less (or writes an empty stub when the theme has none). The euro-office theme override collapses the logo, its navbar, and the associated page padding so no gap is left on screen.

I changed to use the icon, but...

<img width="483" height="265" alt="image" src="https://github.com/user-attachments/assets/122ad3af-d568-48b7-9486-51dc34b9e785" />

I think without is better

<img width="440" height="309" alt="image" src="https://github.com/user-attachments/assets/fb6dbfe8-87ab-426d-8317-5cf042c8d02c" />



