### PR TITLE
fix: correct animation panel icon sizing in presentation editor

### DIFF
--- a/apps/presentationeditor/main/app/view/Animation.js
+++ b/apps/presentationeditor/main/app/view/Animation.js
@@ -201,7 +201,7 @@ define([
                     autoWidth:       true,
                     itemTemplate: _.template([
                         '<div  class = "btn_item x-huge" id = "<%= id %>" style = "width: ' + itemWidth + 'px;height: ' + itemHeight + 'px;">',
-                            '<svg class="icon uni-scale"><use href="#<%= iconCls %>"></use></svg>',
+                            '<svg width="28" height="28"><use href="#<%= iconCls %>"></use></svg>',
                             '<div class = "caption"><%= displayValue %></div>',
                         '</div>'
                     ].join('')),
@@ -513,7 +513,7 @@ define([
                             store: new Common.UI.DataViewStore(Common.define.effectData.getEffectData()),
                             itemTemplate: _.template([
                                 '<div  class = "btn_item x-huge" id = "<%= id %>" style = "width: ' + itemWidth + 'px;height: ' + itemHeight + 'px;">',
-                                    '<svg class="icon uni-scale"><use href="#<%= iconCls %>"></use></svg>',
+                                    '<svg width="28" height="28"><use href="#<%= iconCls %>"></use></svg>',
                                     '<div class = "caption"><%= displayValue %></div>',
                                 '</div>'
                             ].join(''))

--- a/apps/presentationeditor/main/app/view/AnimationDialog.js
+++ b/apps/presentationeditor/main/app/view/AnimationDialog.js
@@ -92,7 +92,7 @@ define([], function () { 'use strict';
                 style: 'max-height: 380px;',
                 itemTemplate: _.template([
                     '<div  class = "btn_item x-huge" id = "<%= id %>" style = "width: ' + 88 + 'px;height: ' + 40 + 'px; pointer-events:none;">',
-                        '<% if (iconCls) { %><svg class="icon uni-scale"><use href="#<%= iconCls %>"></use></svg><% } %>',
+                        '<% if (iconCls) { %><svg width="28" height="28"><use href="#<%= iconCls %>"></use></svg><% } %>',
                         '<div class = "caption"><%= displayValue %></div>',
                     '</div>'
                 ].join('')),


### PR DESCRIPTION
SVG icons in the animation effect picker were rendering at 300px wide (browser default) because the .icon:not(svg) CSS rule explicitly excludes SVG elements from the icon size constraint, and the icon uni-scale class has no dimensions of its own.

Replace with explicit width="28" height="28" matching the 28x28 viewBox. This also avoids fill:currentColor overriding the icons' explicit fill colours.