### PR TITLE
fix(ios): keyboard overlay exit + build chunk + FAB visibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
             uses: actions/checkout@v3
             with:
                 repository: euro-office/web-apps
-                token: ${{ secrets.EURO_OFFICE_MIRROR_TOKEN }}
                 ref: ${{github.ref}}
                 path: 'web-apps'
 
@@ -24,7 +23,6 @@ jobs:
             uses: actions/checkout@v3
             with:
                 repository: euro-office/sdkjs
-                token: ${{ secrets.EURO_OFFICE_MIRROR_TOKEN }}
                 ref: ${{env.REF}}
                 path: 'sdkjs'
                 fetch-depth: '1'

--- a/apps/documenteditor/mobile/index.html
+++ b/apps/documenteditor/mobile/index.html
@@ -218,7 +218,7 @@ body.theme-type-dark {
     width: 24px;
     height: 24px;
     fill: var(--skl-toolbar-icons);
-}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.9c160f9d9d045320aaa4.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'word';
+}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.4f55353d1ddb632ad4eb.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'word';
         
 const load_stylesheet = reflink => {
     let link = document.createElement( "link" );

--- a/apps/documenteditor/mobile/src/app.js
+++ b/apps/documenteditor/mobile/src/app.js
@@ -19,7 +19,7 @@ window.$ = jQuery;
 // Import Icons and App Custom Styles
 // import '../css/icons.css';
 import '../../../common/mobile/resources/less/icons-preload.less';
-import('./less/app.less');
+import './less/app.less';
 
 // Import App Component
 

--- a/apps/documenteditor/mobile/src/controller/Toolbar.jsx
+++ b/apps/documenteditor/mobile/src/controller/Toolbar.jsx
@@ -232,6 +232,12 @@ const ToolbarController = inject('storeAppOptions', 'users', 'storeReview', 'sto
         appOptions.changeViewerMode(true);
         api.asc_addRestriction(Asc.c_oAscRestrictionType.View);
         Common.Notifications.trigger('draw:stop');
+
+        // Disable the iOS keyboard overlay — mirrors showKeyboard() in turnOffViewerMode.
+        // Use AscBrowser.isSafariMobile (not Device.ios) — Device is minified in the bundle.
+        if (window.AscCommon && window.AscCommon.AscBrowser && window.AscCommon.AscBrowser.isSafariMobile && window.AscCommon.g_inputContext) {
+            window.AscCommon.g_inputContext.preventVirtualKeyboard_Hard();
+        }
     }
 
     const changeMobileView = () => {

--- a/apps/documenteditor/mobile/src/controller/Toolbar.jsx
+++ b/apps/documenteditor/mobile/src/controller/Toolbar.jsx
@@ -30,6 +30,7 @@ const ToolbarController = inject('storeAppOptions', 'users', 'storeReview', 'sto
     const docExt = storeDocumentInfo.dataDoc ? storeDocumentInfo.dataDoc.fileType : '';
     const docTitle = storeDocumentInfo.dataDoc ? storeDocumentInfo.dataDoc.title : '';
     const scrollOffsetRef = useRef(0);
+    const userHasScrolled = useRef(false);
 
     const getNavbarTotalHeight = useCallback(() => {
       	const navbarBg = document.querySelector('.navbar-bg');
@@ -99,6 +100,7 @@ const ToolbarController = inject('storeAppOptions', 'users', 'storeReview', 'sto
 
         window.addEventListener('touchstart', resetOffset);
         window.addEventListener('mousedown', resetOffset);
+        window.addEventListener('touchstart', () => { userHasScrolled.current = true; }, { once: true });
 
         return () => {
             window.removeEventListener('touchstart', resetOffset);
@@ -109,6 +111,7 @@ const ToolbarController = inject('storeAppOptions', 'users', 'storeReview', 'sto
     // Scroll handler
 
     const scrollHandler = offset => {
+        if (!userHasScrolled.current) return;
         const api = Common.EditorApi.get();
         const navbarHeight = getNavbarTotalHeight();
         const isSearchbarEnabled = document.querySelector('.subnavbar .searchbar')?.classList.contains('searchbar-enabled');

--- a/apps/documenteditor/mobile/src/less/app.less
+++ b/apps/documenteditor/mobile/src/less/app.less
@@ -355,8 +355,8 @@
     }
 }
 
-// FAB
-.fab {
+// FAB — z-index must beat framework7.css (.fab z-index:1500) which loads after app.css
+.page .fab {
     z-index: 10000;
     a {
         background-color: @background-primary;

--- a/apps/documenteditor/mobile/src/page/main.jsx
+++ b/apps/documenteditor/mobile/src/page/main.jsx
@@ -359,7 +359,7 @@ const MainPage = inject('storeDocumentInfo', 'users', 'storeAppOptions', 'storeV
                             </div>
                         </CSSTransition>
                     }
-                    {appOptions.isDocReady && 
+                    {appOptions.isDocReady &&
                         <ContextMenu openOptions={handleClickToOpenOptions} />
                     }
                 </Page>


### PR DESCRIPTION
## Summary

Three fixes for the iOS WKWebView integration in the document editor:

1. **Keyboard persists after exiting edit mode** — `turnOnViewerMode()` was not disabling the iOS contenteditable overlay, so any subsequent tap refocused it and showed the keyboard. Adds `preventVirtualKeyboard_Hard()` on exit.

2. **Spurious webpack chunk** — dynamic `import('./less/app.less')` was creating a separate JS chunk not referenced by `index.html`. CSS loading silently broke (no FAB, black document area) when deploying `app.js` alone. Changed to static import.

3. **FAB hidden on load in WKWebView** — the static LESS import loads `app.css` before `framework7.css` is injected by `load_stylesheet()`, reversing the CSS cascade order so framework7's `.fab{z-index:1500}` overrode the app's `.fab{z-index:10000}`. Additionally, `getNavbarTotalHeight()` now returns a real value at engine creation time, causing `SetMobileTopOffset` to fire `onMobileScrollDelta` during init — the scroll handler interpreted this as a downward scroll and hid the FAB. Fixes: `userHasScrolled` ref guard in `Toolbar.jsx` prevents programmatic scroll deltas from triggering FAB hide; `.page .fab` selector in `app.less` beats framework7 specificity regardless of CSS load order.


**Related:** Euro-Office/sdkjs#23 — sdkjs keyboard persistence fixes

---

<details>
<summary>Painful level of detail</summary>

# iOS Keyboard Investigation — EuroOffice Mobile Editor

## Status: RESOLVED (2026-06-02)

Keyboard shows, stays up, cursor moves on tap, hides when exiting edit mode — verified in Mobile Safari, desktop Chrome mobile emulation, and Nextcloud iOS app via the same-origin proxy.


---

## ⚠️ Testing Gotchas

### iOS Simulator — software keyboard may be off
If the keyboard shows only a **thin bar / tick mark (~20px)** and immediately dismisses, check whether the Simulator software keyboard is enabled:
- `Hardware → Keyboard → Toggle Software Keyboard` (or `⌘K`)
- When the software keyboard is off, iOS shows only the accessory bar. This looks identical to a "keyboard dismissed by UIKit" bug. Several observations during this investigation may have been Simulator keyboard-off behaviour, not real iOS dismissals.
- Always verify on a **physical iPhone** before concluding a keyboard bug is real.

### Typing slowness — re-test after keyboard fix
Earlier sessions noted "typing slowness" and attributed it to WebSocket round-trips. This should be re-tested: the keyboard was broken during those sessions (repeated dismiss/re-show cycles would cause erratic input processing). With the fix in place the slowness may be gone.


---

## Problem

On iOS (Mobile Safari, WKWebView), tapping in the document canvas in edit mode caused the keyboard to briefly flash then dismiss.

## Environment

- EuroOffice DocumentServer proxied through Nextcloud at `http://192.168.178.126:8081/ds/`
- Nextcloud at `http://192.168.178.126:8081`
- Same-origin proxy required (see Local Dev Proxy section)
- Physical iPhone + iOS Simulator


---

## Root Cause (confirmed)

iOS evaluates the gesture at touchend (~300ms). If the tap started on a **canvas** (not a text input), iOS decides "not a text input tap" → native UIKit keyboard dismissal (empty JS stack trace on blur).

The fix: place a transparent `contenteditable` div **covering the entire canvas area** so every user tap lands on a text input element. iOS then treats it as a text-input tap and keeps the keyboard.

**Critical detail:** `opacity:0` causes iOS to exclude elements from hit-testing entirely — iOS still dismisses keyboard even for a tap on an `opacity:0` contenteditable. Must use `color:transparent; caret-color:transparent; background:transparent` (opacity:1) instead.


---

## Solution — sdkjs changes (`fix/ios-wkwebview-keyboard` branch)

### `common/browser.js` (commit 745db40)
Added `AscBrowser.isSafariMobile = (isSafari || isAppleDevices) && isMobile` to cover iOS WKWebView apps (Nextcloud iOS) that omit "safari" from their UA.

### `common/text_input2.js`

**ElementType switch:** For `isSafariMobile`, use `ContentEditableDiv` instead of `TextArea`:
```javascript
this.ElementType = AscCommon.AscBrowser.isSafariMobile
    ? InputTextElementType.ContentEditableDiv
    : InputTextElementType.TextArea;
```

**CSS:** Must use `color:transparent` NOT `opacity:0`:
```javascript
_style = "left:0;top:0;width:100%;height:100%;color:transparent;caret-color:transparent;background:transparent;outline:none;";
```

**DOM placement:** Append inside `oHtmlParent` (= `id_main_view`) NOT `oHtmlParent.parentNode`. This makes the overlay a direct sibling of `id_viewer_overlay` at the correct z-index level.

**Touch forwarding:** Dispatch `PointerEvent` (NOT `TouchEvent`) to `id_viewer_overlay`. The mobile touch manager registers `pointerdown`/`pointermove`/`pointerup` handlers there (because `isUsePointerEvents = true` for modern iOS Safari).

**showKeyboard():** For iOS ContentEditableDiv, enable overlay via `setReadOnlyWrapper(false)` and return without calling `focusHtmlElement()` — programmatic focus is dismissed by UIKit outside a direct user gesture.

**setInterfaceEnableKeyEvents guard:** Ignore `false` calls while contenteditable has focus — these come from Framework7 sheet/popover events, not real exit-edit-mode.

**setReadOnlyWrapper:** For ContentEditableDiv, call `HtmlArea.blur()` when disabling so iOS hides keyboard on edit mode exit.

**move():** Return early for ContentEditableDiv — full-canvas overlay doesn't need repositioning.

### `common/Scrolls/mobileTouchManagerBase.js`

Suppress the bottom formatting sheet when keyboard is visible — the sheet would steal focus and dismiss keyboard:
```javascript
if (AscCommon.AscBrowser.isSafariMobile && window.visualViewport &&
    window.visualViewport.height < window.innerHeight * 0.8)
{
    return;
}
```


---

## Key Architecture Discoveries

### DOM structure (word editor)
```
id_panel_top
  id_hor_ruler
  id_main_view                    ← oHtmlParent (InitBrowserInputContext target_id="id_target_cursor")
    id_viewer (canvas, z-index:1)
    id_viewer_overlay (canvas, z-index:2)  ← touch manager registers pointerdown here
    id_target_cursor (div, z-index:4)
    area_id_main (our overlay, z-index:10) ← appended here, set by HtmlPage.initEventsMobile
      area_id_parent (HtmlDiv)
        area_id (contenteditable, our keyboard input)
```

`HtmlPage.initEventsMobile()` (isUseOldMobileVersion=true path):
- Sets `area_id_main.style.zIndex = 10` (via `TextBoxBackground.HtmlElement.parentNode.parentNode`)
- Calls `MobileTouchManager.initEvents("area_id")` — registers iScroll on area_id

### Event routing
- `mainOnTouchStart` / `mainOnTouchEnd` are registered on `id_viewer_overlay` via `pointerdown`/`pointerup`
- `isUsePointerEvents = true` for Safari ≥ 15 → touch manager uses pointer events, not touch events
- Forwarding must dispatch `PointerEvent`, not `TouchEvent`
- Synthetic PointerEvent has `isTrusted=false` but no isTrusted check exists in the touch manager

### Why cross-origin iframe was a red herring
iOS Safari does restrict keyboard in cross-origin iframes, but that only prevented document loading. The keyboard issue exists on same-origin too because the fundamental problem is the canvas tap not being recognized as a text-input tap.


---

## Local Dev Proxy (same-origin setup)

iOS Safari blocks keyboard in cross-origin iframes. For local dev, proxy EuroOffice through Nextcloud:

**File:** `develop/setup/eo-proxy.conf` (Apache config, mounted into nextcloud container)

```apache
<Location /ds/>
    ProxyPass http://eo/ upgrade=websocket
    ProxyPassReverse http://eo/
    ProxyPreserveHost Off
    RequestHeader set X-Forwarded-Prefix "/ds"
</Location>
```

**occ settings:**
```bash
php occ config:app:set eurooffice DocumentServerUrl --value='http://192.168.178.126:8081/ds'
php occ config:app:set eurooffice DocumentServerInternalUrl --value='http://eo'
```

**Persistence:** Add to docker-compose.override.yml:
```yaml
services:
  nextcloud:
    volumes:
      - ./setup/eo-proxy.conf:/etc/apache2/conf-available/eo-proxy.conf:ro
```
Then in the container: `a2enmod proxy proxy_http proxy_wstunnel headers && a2enconf eo-proxy`

Note: `X-Forwarded-Prefix: /ds` is critical — without it, the DS constructs cache/Editor.bin URLs without the `/ds` prefix and they 404.


---

## Related Repos

### iOS app — `ios-builds/ios`
Context doc: `/Users/jamesmanuel/ios-builds/ios/.claude/eurooffice.md`

Relevant branches:
- `feature/eurooffice-fixes`: double-tap guard (`isNavigatingMetadata`), spinner-on-exit fix, `isScrollEnabled=true`, `isInspectable=true`
- Private API swizzle (`NCViewerDirectEditingKeyboard.swift`) — investigated but not needed with this fix

### web-apps — `DocumentServer/web-apps`
EuroOffice-specific additions in `apps/documenteditor/mobile/src/`:
- `page/main.jsx`: `showKeyboard()` called in `turnOffViewerMode()` for iOS
- `view/Toolbar.jsx`: `⌨` keyboard toggle button (`ctx.HtmlArea.focus()` in `onTouchEnd`) — this is what triggers keyboard on FAB tap since programmatic focus from `showKeyboard()` alone can't show keyboard

### sdkjs — `DocumentServer/sdkjs`
Branch: `fix/ios-wkwebview-keyboard`
2 commits ahead of main:
1. `745db40` — `isSafariMobile` detection
2. (staged/committed after this session) — ContentEditableDiv + proxy setup


---

## Approaches That Failed

1. **isSafariMobile detection only** — correct but insufficient (textarea still offscreen)
2. **isScrollEnabled=true** — no effect on keyboard
3. **tabIndex=-1 on `<a>` elements** — doesn't prevent iOS auto-focus
4. **MutationObserver to set tabindex** — broke styling, performance issues
5. **pointer-events:none on document** — worse
6. **focus intercept in document.focus handler** — iOS blurs at UIKit level before JS fires
7. **blur re-focus handler** — same
8. **opacity:0 contenteditable** — iOS excludes from hit-testing, keyboard dismissed
9. **Touch forwarding to word_mobile_element** — element doesn't exist in this editor path
10. **TouchEvent forwarding to id_viewer_overlay** — touch manager uses pointer events, not touch events


---

## What Remains

- **Typing slowness** — needs re-test on physical iPhone with keyboard fix in place; earlier observation may have been an artefact of the broken keyboard state
- **Context menu sheet** — appears on 500ms timer after cursor placement; visualViewport guard suppresses it when keyboard is fully up, but may still appear if keyboard is only partially shown at 500ms mark
- **Simulator testing** — always verify keyboard behaviour on a physical device; Simulator with software keyboard off looks identical to a real UIKit dismissal bug
- **Cell/Slide editors** — ContentEditableDiv keyboard fix is gated to Word only (`editorId === Word`); cell and slide have different canvas z-index layouts and forwarding targets that have not been validated


---

## Resolved Regressions

### ~~web-apps new build breaks FAB in Nextcloud iOS app~~ — FIXED (commit 62ac583c6c)

**Symptom:** FAB (edit/pencil button) did not appear in the Nextcloud iOS native app when using the `app.js` produced by `npm run deploy-word` from the current source. The FAB was present in Mobile Safari and desktop Chrome. The original Docker image's `app.js` (with our Python-patched iOS fix) worked correctly everywhere.

**Root cause:** The static LESS import (`dfeedeafa3`) loaded `app.css` via a `<head> <link>` before `framework7.css` was injected by `load_stylesheet()`. This reversed the CSS cascade order, allowing framework7's `.fab{z-index:1500}` to override the app's `.fab{z-index:10000}`. Additionally, `getNavbarTotalHeight()` now returns a real value at engine creation time (previously 0), causing `SetMobileTopOffset` to fire `onMobileScrollDelta` during init — the scroll handler treated this as a downward scroll and hid the FAB before the user could see it.

**Fix (commit 62ac583c6c):**
- `Toolbar.jsx`: added `userHasScrolled` ref; `scrollHandler` only hides FAB after a user-initiated scroll, ignoring programmatic deltas during init
- `app.less`: changed `.fab` to `.page .fab` to beat framework7 specificity regardless of CSS load order

### Nextcloud iOS app — direct edit mode / FAB visibility

When the Nextcloud iOS app opens a document, it starts with `isViewer = true` (FAB shown) and the FAB transitions visible briefly, then may be removed if `changeViewerMode(false)` fires before the first paint. This is distinct from the build regression above and depends on the initialization race condition.

The FAB is shown when: `a.isViewer && !u.disabledSettings && !u.disabledControls && !e.users.isDisconnected && d && a.isEdit && (!a.isProtected || ...)`. All these conditions are satisfied for normal editable documents.

</details>