### PR TITLE
build: disable terser mangling

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -510,6 +510,7 @@ module.exports = function(grunt) {
         return {
             terser: {
                 options: {
+                    mangle: false,
                     format: {
                         preamble: '/** vim: et:ts=4:sw=4:sts=4\n' +
                             ' * @license RequireJS 2.1.2 Copyright (c) 2010-2012, The Dojo Foundation All Rights Reserved.\n' +
@@ -667,6 +668,7 @@ module.exports = function(grunt) {
             // IE compatibility for babel-transpiled files - unnecessary overhead for modern builds.
             terser: {
                 options: {
+                    mangle: false,
                     format: {
                         comments: false,
                         preamble: "/* minified by terser */",
@@ -716,6 +718,7 @@ module.exports = function(grunt) {
             pkg: packageFile,
             terser: {
                 options: {
+                    mangle: false,
                     format: {
                         comments: false,
                         preamble: copyright,
@@ -883,6 +886,7 @@ module.exports = function(grunt) {
 
             terser: {
                 options: {
+                    mangle: false,
                     format: {
                         comments: false,
                         preamble: copyright,
@@ -954,6 +958,7 @@ module.exports = function(grunt) {
 
             terser: {
                 options: {
+                    mangle: false,
                     format: {
                         comments: false,
                         preamble: copyright,


### PR DESCRIPTION
Sets `mangle: false` on all terser tasks (requirejs, main, reporter, embed, test) so minified output keeps identifier names. Easier to read stack traces and debug production builds.