### PR TITLE
fix: :art: Improve readability of long error messages in ErrorBoundary dialog

### DIFF
--- a/apps/common/mobile/resources/less/common.less
+++ b/apps/common/mobile/resources/less/common.less
@@ -1189,12 +1189,12 @@ input[type="number"]::-webkit-inner-spin-button {
             color: @text-error;
             text-align: left;
             overflow-wrap: break-word;
+            white-space: pre-wrap;
             display: -webkit-box;
-            -webkit-line-clamp: 7;
+            -webkit-line-clamp: 12;
             -webkit-box-orient: vertical;
             overflow: hidden;
             text-overflow: ellipsis;
-            max-height: 120px;
         }
     }
 


### PR DESCRIPTION
- white-space: pre-wrap for stack-trace newlines and indentation
- -webkit-line-clamp increase from 7 to 12 for more context per dialog
- drop redundant max-height

## How to trigger the dialog

  Open any mobile editor, then in the editor iframe's DevTools console:

  ```js
  (() => {
      const app = document.getElementById('app');
      const reactKey = Object.keys(app).find(k => k.startsWith('__reactContainer'));
      const find = f => {
          if (!f) return null;
          const n = f.stateNode, t = f.type;
          if (n && typeof n.componentDidCatch === 'function' && typeof t?.getDerivedStateFromError === 'function') return n;
          return find(f.child) || find(f.sibling);
      };
      const eb = find(app[reactKey].stateNode.current);
      eb.componentDidCatch(new Error(
          "ReferenceError: someVariable is not defined\n" +
          "    at Object.handleClick (app.js:12345:67)\n" +
          "    at HTMLButtonElement.onClick (Component.jsx:42:18)\n" +
          "    at executeDispatch (react-dom.production.min.js:5481:9)\n" +
          "    at processDispatchQueue (react-dom.production.min.js:5512:9)"
      ));
  })();
  ```

  ## Before / after — last line clipping

  | Before (max-height: 120px, clamp 7) | After (no max-height, clamp 12, pre-wrap) |
  |---|---|
  | ![before](https://github.com/user-attachments/assets/b1a62630-767f-45ce-bbff-ecda6953e814) | ![after](https://github.com/user-attachments/assets/4eb91d87-c0a9-44fa-9d1d-d9f53c86a1a2) |


 ## Test checklist

  - [ ] Stack-trace lines render on separate rows with indentation
  - [ ] Last visible line is fully shown or replaced by `…`, not half-clipped
  - [ ] Short texts are shown in the same way as before
