### PR TITLE
DE/PE mobile: Fix getEditCommentControllers using already added controllers

### DIFF
--- a/apps/documenteditor/mobile/src/lib/editor.jsx
+++ b/apps/documenteditor/mobile/src/lib/editor.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { Link } from 'framework7-react';
-import { CommentsController, ViewCommentsController } from '../../../../common/mobile/lib/controller/collaboration/Comments';
+import { AddCommentController, EditCommentController } from '../../../../common/mobile/lib/controller/collaboration/Comments';
 import {
     PlatformIcon,
     buildFocusObjectGetters,
@@ -172,12 +172,12 @@ export const updateChartStyles = (storeChartSettings, storeFocusObjects) => {
 
 /**
  * Renders comment controller components for editing mode
- * @returns {JSX.Element} Fragment containing CommentsController and ViewCommentsController
+ * @returns {JSX.Element} Fragment containing AddCommentController and EditCommentController
  */
 export const getEditCommentControllers = () => (
     <Fragment>
-        <CommentsController />
-        <ViewCommentsController />
+        <AddCommentController />
+        <EditCommentController />
     </Fragment>
 );
 

--- a/apps/presentationeditor/mobile/src/lib/editor.jsx
+++ b/apps/presentationeditor/mobile/src/lib/editor.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { Link } from 'framework7-react';
 import { Device } from '../../../../common/mobile/utils/device';
-import { CommentsController, ViewCommentsController } from '../../../../common/mobile/lib/controller/collaboration/Comments';
+import { AddCommentController, EditCommentController } from '../../../../common/mobile/lib/controller/collaboration/Comments';
 import {
     PlatformIcon,
     buildFocusObjectGetters,
@@ -228,12 +228,12 @@ export const updateChartStyles = (storeChartSettings, storeFocusObjects) => {
 
 /**
  * Renders comment controller components for editing mode
- * @returns {JSX.Element} Fragment containing CommentsController and ViewCommentsController
+ * @returns {JSX.Element} Fragment containing AddCommentController and EditCommentController
  */
 export const getEditCommentControllers = () => (
     <Fragment>
-        <CommentsController />
-        <ViewCommentsController />
+        <AddCommentController />
+        <EditCommentController />
     </Fragment>
 );
 


### PR DESCRIPTION
While working on a draft PR for #88, I found out that the `getEditCommentControllers` in editor.jsx were implemented incorrectly for documenteditor and presentationeditor. (spreadsheeteditor doesn't have that method and is therefore fine)

It is adding controllers that are added in Main.jsx ([documenteditor](https://github.com/Euro-Office/web-apps/blob/53dd1a19a7a9a7dc670545e6a04443b7b8a31ea1/apps/documenteditor/mobile/src/controller/Main.jsx#L1682-L1684) and [presentationeditor](https://github.com/Euro-Office/web-apps/blob/53dd1a19a7a9a7dc670545e6a04443b7b8a31ea1/apps/presentationeditor/mobile/src/controller/Main.jsx#L1213-L1215)), so it wasn't doing anything. I added the expected controllers to allow adding and editing comments. 

Right now it doesn't do anything as it needs the context menu actions to be shown and handled in order to open the comments but here's the diff from before ONLYOFFICE removed their mobile editor to show that's what's supposed to be there:
* documenteditor: https://github.com/Euro-Office/web-apps/commit/45a9058da461a9da67ccb389faad08bce8cbda55#diff-e02881fa2158c2909c0fb78180c1e55f2cc41db27579bfcc1e7844bc4e0f03bdL785-R775
* presentation: https://github.com/Euro-Office/web-apps/commit/45a9058da461a9da67ccb389faad08bce8cbda55#diff-1d89c904c6cd5147fb6942c09c4d12a2f3a3200a61b3e29b1a42a1263e57848bL307-R303