### PR TITLE
🐛 fix(sse): only render sheet-view icon SVG when sheet has active sheet view

### DIFF
--- a/apps/spreadsheeteditor/main/app/view/Statusbar.js
+++ b/apps/spreadsheeteditor/main/app/view/Statusbar.js
@@ -474,7 +474,7 @@ define([
                             cls           : locked ? 'coauth-locked':'',
                             disabled      : me.mode.isBackgroundOpen,
                             isLockTheDrag : locked || me.mode.isDisconnected || me.mode.isBackgroundOpen || wbprotected,
-                            iconCls       : 'btn-sheet-view',
+                            iconCls       : name !== '' ? 'btn-sheet-view' : '',
                             iconTitle     : name,
                             iconVisible   : name!==''
                         };


### PR DESCRIPTION
## Summary

- `iconCls` was unconditionally set to `'btn-sheet-view'` on every sheet tab, causing the browser's default SVG size (300×150px) to be rendered when `icon-visible` was absent — pushing the sheet tab label text completely offscreen
- Guard `iconCls` with the same condition as `iconVisible` so no SVG element is inserted for tabs without an active named sheet view
- The icon still appears correctly when a sheet has an active named sheet view (View → Sheet View → New)

## Root cause

The switch from PNG background-image sprites to inline SVG (`<use href="#btn-sheet-view">`) exposed a pre-existing issue: an `<svg>` element with no explicit container size falls back to the browser default of 300×150px. The old CSS background-image was invisible at zero size; the SVG is not.

## Test plan

- [ ] Open a spreadsheet with multiple sheets — all tab labels should be visible
- [ ] Create a named sheet view (View → Sheet View → New) on one sheet — icon should appear on that tab only
- [ ] Confirm no layout regression on sheet tabs with/without named sheet views

Closes #110
Closes Euro-Office/DocumentServer#150

🤖 Generated with [Claude Code](https://claude.ai/code)