### PR TITLE
ci: add CODEOWNERS for frontend team review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @euro-office/frontend


### PR DESCRIPTION
Adds a CODEOWNERS file so every PR auto-requests review from the frontend team (matching sdkjs/core).

```
* @euro-office/frontend
```

This would request reviews from anyone in @Euro-Office/frontend 