### PR TITLE
🐛 fix(pe): replace CSS class icon with SVG use in transitions picker

### DIFF
--- a/apps/common/main/resources/less/bigscaling.less
+++ b/apps/common/main/resources/less/bigscaling.less
@@ -29,7 +29,7 @@
     }
 
     .dataview {
-        &:not(.scaling-off) .options__icon {
+        &:not(.scaling-off) .icon:not(svg).options__icon {
             display: none;
         }
         svg.icon {

--- a/apps/common/main/resources/less/combo-dataview.less
+++ b/apps/common/main/resources/less/combo-dataview.less
@@ -527,6 +527,15 @@
             flex-shrink: 0;
         }
 
+        svg.icon {
+            width: @x-huge-btn-icon-size-ie;
+            width: @x-huge-btn-icon-size;
+            height: @x-huge-btn-icon-size-ie;
+            height: @x-huge-btn-icon-size;
+            min-width: 0;
+            flex-shrink: 0;
+        }
+
         .caption{
             line-height: 12px;
             text-overflow: ellipsis;

--- a/apps/presentationeditor/main/app/view/Transitions.js
+++ b/apps/presentationeditor/main/app/view/Transitions.js
@@ -139,7 +139,7 @@ define([
                     autoWidth:       true,
                     itemTemplate: _.template([
                         '<div  class = "btn_item x-huge" id = "<%= id %>" style = "width: ' + itemWidth + 'px;height: ' + itemHeight + 'px;">',
-                        '<div class = "icon toolbar__icon options__icon <%= imageUrl %>"></div>',
+                        '<svg class=\"icon uni-scale options__icon\"><use href=\"#<%= imageUrl %>\"></use></svg>',
                         '<div class = "caption"><%= title %></div>',
                         '</div>'
                     ].join('')),


### PR DESCRIPTION
## Summary

- All 11 transition effect icons in the presentation editor's slide transitions panel were blank after PNG sprites were removed
- Replace the `<div class="icon toolbar__icon options__icon <%= imageUrl %>">` template with `<svg class="icon uni-scale options__icon"><use href="#<%= imageUrl %>"></use></svg>`
- Fix two LESS rules that implicitly assumed the icon element was a non-SVG element

## Changes

**`apps/presentationeditor/main/app/view/Transitions.js`** — swap `<div>` CSS class icon for `<svg><use>` in the `ComboDataView` item template.

**`apps/common/main/resources/less/combo-dataview.less`** — add `svg.icon` sizing alongside the existing `.icon:not(svg)` rule in `.btn_item` so SVG icons get explicit dimensions in the flex container.

**`apps/common/main/resources/less/bigscaling.less`** — scope `.options__icon { display: none }` at 2.5x pixel ratio to `.icon:not(svg)` only. PNG icons needed hiding at 2.5x; SVGs scale naturally and must not be hidden.

## Test plan

- [ ] Open any presentation in the presentation editor
- [ ] Open the Transitions panel (Transitions tab → click effect picker)
- [ ] All 11 transition icons should render correctly
- [ ] Verify on a 2.5x display (or devtools device scaling) — icons should still be visible
- [ ] Verify no regression in other `ComboDataView` usages (animation picker)

Closes #101

🤖 Generated with [Claude Code](https://claude.ai/code)