### PR TITLE
fix(Button): update SVG <use href> in changeIcon for btn-* icons

### DIFF
--- a/apps/common/main/lib/component/Button.js
+++ b/apps/common/main/lib/component/Button.js
@@ -796,6 +796,11 @@ define([
                 }
                 svgIcon.length && !!opts.next && svgIcon.attr('href', '#' + opts.next);
 
+                if (!svgIcon.length && opts.next) {
+                    var svgUse = $(this.el).find('svg.icon use');
+                    svgUse.length && svgUse.attr('href', '#' + opts.next);
+                }
+
                 if ( !!me.options.signals ) {
                     if ( !(me.options.signals.indexOf('icon:changed') < 0) ) {
                         me.trigger('icon:changed', me, opts);


### PR DESCRIPTION
Fixes #114

## Summary

- `changeIcon()` in `Button.js` was manipulating `i.icon` elements and `use.zoom-int`, neither of which exist in SVG-rendered buttons (`<svg class="icon uni-scale"><use href="#btn-xxx">`)
- The DOM was never updated on click, so icons like favourite, play/pause, print, markers, and collaboration changes showed no visual feedback despite the action completing
- Fix adds a fallback: when the `zoom-int` path finds nothing, finds `svg.icon use` and updates its `href` directly

## Test plan

- [ ] Open a document, click the favourite (star) button — icon should toggle between outline and filled star immediately
- [ ] Open presentation preview — play/pause button icon should toggle on click
- [ ] Build passes (`make web-apps-dev` in `eo` container) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)