### PR TITLE
feat(documenteditor): add Pageless view toggle

### DIFF
--- a/apps/documenteditor/main/app/controller/Main.js
+++ b/apps/documenteditor/main/app/controller/Main.js
@@ -1342,6 +1342,10 @@ define([
                         this.api.zoom(zf > 0 ? zf : 100);
                 }
 
+                if (Common.localStorage.getBool("de-pageless-mode", false)) {
+                    this.api.SetPagelessMode(true);
+                }
+
                 value = Common.localStorage.getItem("de-show-hiddenchars");
                 me.api.put_ShowParaMarks((value!==null) ? eval(value) : false);
 

--- a/apps/documenteditor/main/app/controller/ViewTab.js
+++ b/apps/documenteditor/main/app/controller/ViewTab.js
@@ -90,7 +90,8 @@ define([
                     'macros:pause':  _.bind(this.onClickMacrosPause, this),
                     'pointer:select': _.bind(this.onPointerType, this, 'select'),
                     'pointer:hand': _.bind(this.onPointerType, this, 'hand'),
-                    'pages:multiple': _.bind(this.onMultiplePages, this)
+                    'pages:multiple': _.bind(this.onMultiplePages, this),
+                    'pages:pageless': _.bind(this.onPagelessMode, this)
                 },
                 'Toolbar': {
                     'view:compact': _.bind(function (toolbar, state) {
@@ -106,6 +107,11 @@ define([
                         this.api.SetMultipageViewMode(isMultiple);
                         Common.localStorage.setBool("de-zoom-multipage", isMultiple);
                         this.view.btnMultiplePages.toggle(isMultiple);
+                    }, this),
+                    'pages:pagelesschanged': _.bind(function (isPageless) {
+                        this.api.SetPagelessMode(isPageless);
+                        Common.localStorage.setBool("de-pageless-mode", isPageless);
+                        this.view.btnPageless.toggle(isPageless);
                     }, this)
                 },
                 'LeftMenu': {
@@ -288,6 +294,13 @@ define([
                 this.api.SetMultipageViewMode(pressed);
                 Common.localStorage.setBool("de-zoom-multipage", pressed);
                 this.view.fireEvent('pages:multiplechanged', [pressed]);
+            }
+        },
+
+        onPagelessMode: function (pressed) {
+            if (this.api) {
+                this.api.SetPagelessMode(pressed);
+                Common.localStorage.setBool("de-pageless-mode", pressed);
             }
         },
 

--- a/apps/documenteditor/main/app/view/ViewTab.js
+++ b/apps/documenteditor/main/app/view/ViewTab.js
@@ -70,6 +70,7 @@ define([
                 '</div>' +
                 '<div class="elset">' +
                     '<span class="btn-slot text" id="slot-btn-multiple-pages" style="text-align: center;"></span>' +
+                    '<span class="btn-slot text" id="slot-btn-pageless" style="text-align: center;"></span>' +
                 '</div>' +
             '</div>' +
             '<div class="separator long"></div>' +
@@ -153,6 +154,9 @@ define([
                 }, me));
                 me.btnMultiplePages.on('click', _.bind(function (e) {
                     me.fireEvent('pages:multiple', [e.pressed]);
+                }, me));
+                me.btnPageless.on('click', _.bind(function (e) {
+                    me.fireEvent('pages:pageless', [e.pressed]);
                 }, me));
                 me.btnZoom100.on('click', _.bind(function (e) {
                     me.fireEvent('zoom:100');
@@ -313,6 +317,19 @@ define([
                 });
                 this.lockedControls.push(this.btnMultiplePages);
 
+                this.btnPageless = new Common.UI.Button({
+                    cls: 'btn-toolbar',
+                    iconCls: 'toolbar__icon btn-multiple-pages',
+                    lock: [_set.lostConnect, _set.disableOnStart],
+                    caption: this.textPageless,
+                    pressed: Common.localStorage.getBool("de-pageless-mode", false),
+                    enableToggle: true,
+                    dataHint: '1',
+                    dataHintDirection: 'bottom',
+                    dataHintOffset: 'small',
+                });
+                this.lockedControls.push(this.btnPageless);
+
                 this.btnZoom100 = new Common.UI.Button({
                     cls: 'btn-toolbar',
                     iconCls: 'toolbar__icon btn-zoom-100',
@@ -440,6 +457,7 @@ define([
                 this.btnInterfaceTheme.render($host.find('#slot-btn-interface-theme'));
                 this.btnDarkDocument.render($host.find('#slot-btn-dark-document'));
                 this.btnMultiplePages.render($host.find('#slot-btn-multiple-pages'));
+                this.btnPageless.render($host.find('#slot-btn-pageless'));
                 this.btnZoom100.render($host.find('#slot-btn-zoom-100'));
                 this.chStatusbar.render($host.find('#slot-chk-statusbar'));
                 this.chToolbar.render($host.find('#slot-chk-toolbar'));
@@ -545,6 +563,7 @@ define([
             textAlwaysShowToolbar: 'Always show toolbar',
             textRulers: 'Rulers',
             textDarkDocument: 'Dark document',
+            textPageless: 'Pageless',
             tipHeadings: 'Headings',
             tipFitToPage: 'Fit to page',
             tipFitToWidth: 'Fit to width',

--- a/apps/documenteditor/main/locale/en.json
+++ b/apps/documenteditor/main/locale/en.json
@@ -4326,6 +4326,7 @@
   "DE.Views.ViewTab.textLine": "Line",
   "DE.Views.ViewTab.textMacros": "Macros",
   "DE.Views.ViewTab.textMultiplePages": "Multiple Pages",
+  "DE.Views.ViewTab.textPageless": "Pageless",
   "DE.Views.ViewTab.textNavigation": "Navigation",
   "DE.Views.ViewTab.textOutline": "Headings",
   "DE.Views.ViewTab.textPauseMacro": "Pause recording",


### PR DESCRIPTION
Pageless view for the document editor

Requires https://github.com/Euro-Office/sdkjs/pull/53

Adds a **Pageless** toggle to the document editor's View tab. When enabled, the engine renders the document as one continuous sheet (no page gaps/outlines). Mirrors the existing Multiple Pages toggle end-to-end.

## Changes
- `view/ViewTab.js`: new `btnPageless` toggle button, slot, click event, render, and `textPageless` string.
- `controller/ViewTab.js`: `onPagelessMode` handler + `pages:pageless` wiring; calls `api.SetPagelessMode(...)` and persists to `localStorage["de-pageless-mode"]`.
- `controller/Main.js`: restores the saved preference on editor load so it survives reload.
- `locale/en.json`: `DE.Views.ViewTab.textPageless` (English; other locales fall back).

## Notes
- Requires the engine API `SetPagelessMode`/`GetPagelessMode` (see the sdkjs PR).
- View preference only — per-user, does not modify the document or affect collaborators.
- Icon currently reuses the multiple-pages glyph as a placeholder; a dedicated icon can follow.

<img width="1500" height="951" alt="Screenshot 2026-06-17 at 14 26 05" src="https://github.com/user-attachments/assets/862a7d2f-a264-4c92-aa98-242e9d0b78f5" />
