### PR TITLE
fix: gate document:ready on script:loaded in PDF editor

### DIFF
--- a/apps/pdfeditor/main/app/controller/Main.js
+++ b/apps/pdfeditor/main/app/controller/Main.js
@@ -1135,8 +1135,7 @@ define([
 
                     me.appOptions.isRestrictedEdit && me.api.asc_SetHighlightRequiredFields(true);
 
-                    var timer_sl = setTimeout(function(){
-
+                    var fireDocumentReady = function() {
                         toolbarController.createDelayedElements();
                         toolbarController.activateControls();
                         documentHolderController.applyEditorMode();
@@ -1147,6 +1146,13 @@ define([
 
                         Common.NotificationCenter.trigger('document:ready', 'main');
                         me.applyLicense();
+                    };
+                    setTimeout(function(){
+                        if (!Common.Controllers.LaunchController.isScriptLoaded()) {
+                            Common.NotificationCenter.once('script:loaded', fireDocumentReady);
+                        } else {
+                            fireDocumentReady();
+                        }
                     }, 500);
                 } else {
                     Common.NotificationCenter.trigger('document:ready', 'main');


### PR DESCRIPTION
The 500ms setTimeout before triggering document:ready was a race condition: postLaunchScripts (including the FormsTab view class) load asynchronously after app:ready, but in dev mode 30+ individual files consistently take longer than 500ms to load. When Toolbar.applyMode called FormsTab.setConfig before PDFE.Views.FormsTab was defined, createView received undefined as the view constructor, leaving _viewsCache in an inconsistent state and triggering EditingError -25 ("An error occurred during the work with the document").

After the 500ms minimum, check LaunchController.isScriptLoaded(). If scripts are still loading, defer fireDocumentReady until script:loaded fires — the same pattern already used throughout DocumentHolderExt, LeftMenu and Toolbar in this editor.

Fixes #38

Assisted-by: ClaudeCode:claude-sonnet-4-6