### PR TITLE
fix(theme): add --icon-gray-primary to dark and contrast-dark themes

### DIFF
--- a/apps/common/main/resources/less/colors-table-dark-contrast.less
+++ b/apps/common/main/resources/less/colors-table-dark-contrast.less
@@ -69,6 +69,8 @@
         --icon-normal-pressed: #e8e8e8;
         --icon-toolbar-header: #d0d0d0;
         --icon-success: #090;
+        --icon-gray-primary: #e8e8e8;
+        --icon-blue-primary: #92b7f0;
 
         --highlight-header-tab-underline-document: var(--text-toolbar-header);
         --highlight-header-tab-underline-spreadsheet: var(--text-toolbar-header);

--- a/apps/common/main/resources/less/colors-table-dark.less
+++ b/apps/common/main/resources/less/colors-table-dark.less
@@ -70,6 +70,8 @@
         --icon-normal-pressed: fade(#fff, 80%);
         --icon-toolbar-header: fade(#fff, 80%);
         --icon-success: #090;
+        --icon-gray-primary: fade(#fff, 80%);
+        --icon-blue-primary: #92b7f0;
 
         --highlight-header-tab-underline-document: var(--text-toolbar-header);
         --highlight-header-tab-underline-spreadsheet: var(--text-toolbar-header);


### PR DESCRIPTION
Fixes #120

## Problem

Both dark themes (`theme-dark`, `theme-contrast-dark`) were missing `--icon-gray-primary`. All SVG toolbar icons use:

```css
svg.icon { color: var(--icon-gray-primary, #383838); }
```

Without the variable defined, icons fall back to `#383838` (near-black) — nearly invisible on a dark background. The night theme already defines this correctly; dark and contrast-dark did not.

## Fix

Added `--icon-gray-primary` and `--icon-blue-primary` to both dark theme color tables, matching the values already used for `--icon-normal` in each theme:

| Theme | `--icon-gray-primary` | `--icon-blue-primary` |
|---|---|---|
| dark | `fade(#fff, 80%)` | `#92b7f0` |
| contrast-dark | `#e8e8e8` | `#92b7f0` |

## Testing

- [ ] Switch to Dark theme — toolbar icons visible
- [ ] Switch to Contrast Dark theme — toolbar icons visible
- [ ] Light/Classic/Night themes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)