### PR TITLE
🐛 fix(branding): remove ONLYOFFICE branding from loader and unlock customization (#89)

### DIFF
--- a/apps/documenteditor/main/app/controller/Main.js
+++ b/apps/documenteditor/main/app/controller/Main.js
@@ -1791,7 +1791,7 @@ define([
 
                 this.appOptions.fileKey = this.document.key;
 
-                this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                 Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
 

--- a/apps/documenteditor/main/index.html.deploy
+++ b/apps/documenteditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/documenteditor/main/index_loader.html.deploy
+++ b/apps/documenteditor/main/index_loader.html.deploy
@@ -15,8 +15,8 @@
         .loader-logo-light,
         .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
         .loader-logo-dark { display: none; }
-        .theme-dark .loader-logo-light { display: none; }
-        .theme-dark .loader-logo-dark { display: inline-block; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
 
         .theme-dark {
             --romb-start-color: #555;
@@ -72,11 +72,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 

--- a/apps/documenteditor/main/index_loader.html.deploy
+++ b/apps/documenteditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -12,6 +12,12 @@
     <!-- splash -->
 
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-dark .loader-logo-light { display: none; }
+        .theme-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -275,11 +281,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                     '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                         ((logo!==null) ? logo :
-                        '<div class="loader-page-romb">' +
-                            '<div class="romb" id="blue"></div>' +
-                            '<div class="romb" id="green"></div>' +
-                            '<div class="romb" id="red"></div>' +
-                        '</div>') +
+                        '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                     '</div>' +
                     '<div class="loader-page-text">' +  customer +
                         '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/pdfeditor/main/app/controller/Main.js
+++ b/apps/pdfeditor/main/app/controller/Main.js
@@ -1398,7 +1398,7 @@ define([
 
                 this.appOptions.fileKey = this.document.key;
 
-                this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                 Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                 Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!

--- a/apps/pdfeditor/main/index.html.deploy
+++ b/apps/pdfeditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE PDF Editor</title>
+    <title>{{APP_TITLE_TEXT}} PDF Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/pdfeditor/main/index_loader.html.deploy
+++ b/apps/pdfeditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE PDF Editor</title>
+    <title>{{APP_TITLE_TEXT}} PDF Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -11,6 +11,12 @@
     <!-- splash -->
 
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-dark .loader-logo-light { display: none; }
+        .theme-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -274,11 +280,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                     '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                         ((logo!==null) ? logo :
-                        '<div class="loader-page-romb">' +
-                            '<div class="romb" id="blue"></div>' +
-                            '<div class="romb" id="green"></div>' +
-                            '<div class="romb" id="red"></div>' +
-                        '</div>') +
+                        '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                     '</div>' +
                     '<div class="loader-page-text">' +  customer +
                         '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/pdfeditor/main/index_loader.html.deploy
+++ b/apps/pdfeditor/main/index_loader.html.deploy
@@ -14,8 +14,8 @@
         .loader-logo-light,
         .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
         .loader-logo-dark { display: none; }
-        .theme-dark .loader-logo-light { display: none; }
-        .theme-dark .loader-logo-dark { display: inline-block; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
 
         .theme-dark {
             --romb-start-color: #555;
@@ -71,11 +71,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 

--- a/apps/presentationeditor/main/app/controller/Main.js
+++ b/apps/presentationeditor/main/app/controller/Main.js
@@ -1392,7 +1392,7 @@ define([
                     this.appOptions.canUseHistory = false;
                 }
 
-                this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                 Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
 

--- a/apps/presentationeditor/main/index.html.deploy
+++ b/apps/presentationeditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="width:100%; height:100%;">
 <head>
-    <title>ONLYOFFICE Presentation Editor</title>
+    <title>{{APP_TITLE_TEXT}} Presentation Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/presentationeditor/main/index_loader.html.deploy
+++ b/apps/presentationeditor/main/index_loader.html.deploy
@@ -14,8 +14,8 @@
         .loader-logo-light,
         .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
         .loader-logo-dark { display: none; }
-        .theme-dark .loader-logo-light { display: none; }
-        .theme-dark .loader-logo-dark { display: inline-block; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
 
         .theme-dark {
             --romb-start-color: #555;
@@ -71,11 +71,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 

--- a/apps/presentationeditor/main/index_loader.html.deploy
+++ b/apps/presentationeditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="width:100%; height:100%;">
 <head>
-    <title>ONLYOFFICE Presentation Editor</title>
+    <title>{{APP_TITLE_TEXT}} Presentation Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -11,6 +11,12 @@
     <!-- splash -->        
 
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-dark .loader-logo-light { display: none; }
+        .theme-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -274,11 +280,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                         '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                             ((logo!==null) ? logo :
-                            '<div class="loader-page-romb">' +
-                                '<div class="romb" id="blue"></div>' +
-                                '<div class="romb" id="green"></div>' +
-                                '<div class="romb" id="red"></div>' +
-                            '</div>') +
+                            '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                         '</div>' +
                         '<div class="loader-page-text">' +  customer +
                             '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/spreadsheeteditor/main/app/controller/Main.js
+++ b/apps/spreadsheeteditor/main/app/controller/Main.js
@@ -1452,7 +1452,7 @@ define([
                     this.appOptions.isBeta         = params.asc_getIsBeta();
                     this.appOptions.canModifyFilter = (this.permissions.modifyFilter!==false);
 
-                    this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                    this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                     Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                     this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                     Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!

--- a/apps/spreadsheeteditor/main/index.html.deploy
+++ b/apps/spreadsheeteditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/spreadsheeteditor/main/index_internal.html.deploy
+++ b/apps/spreadsheeteditor/main/index_internal.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/spreadsheeteditor/main/index_loader.html.deploy
+++ b/apps/spreadsheeteditor/main/index_loader.html.deploy
@@ -14,8 +14,8 @@
         .loader-logo-light,
         .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
         .loader-logo-dark { display: none; }
-        .theme-dark .loader-logo-light { display: none; }
-        .theme-dark .loader-logo-dark { display: inline-block; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
 
         .theme-dark {
             --romb-start-color: #555;
@@ -71,11 +71,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 

--- a/apps/spreadsheeteditor/main/index_loader.html.deploy
+++ b/apps/spreadsheeteditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -11,6 +11,12 @@
 
     <!-- splash -->
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-dark .loader-logo-light { display: none; }
+        .theme-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -274,11 +280,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                     '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                         ((logo!==null) ? logo :
-                            '<div class="loader-page-romb">' +
-                                '<div class="romb" id="blue"></div>' +
-                                '<div class="romb" id="green"></div>' +
-                                '<div class="romb" id="red"></div>' +
-                            '</div>') +
+                            '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                     '</div>' +
                     '<div class="loader-page-text">' +  customer +
                         '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/visioeditor/main/app/controller/Main.js
+++ b/apps/visioeditor/main/app/controller/Main.js
@@ -1189,7 +1189,7 @@ define([
                     this.appOptions.canUseHistory = false;
                 }
 
-                this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                 Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                 Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!

--- a/apps/visioeditor/main/index.html.deploy
+++ b/apps/visioeditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="width:100%; height:100%;">
 <head>
-    <title>ONLYOFFICE Visio Editor</title>
+    <title>{{APP_TITLE_TEXT}} Visio Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/visioeditor/main/index_loader.html.deploy
+++ b/apps/visioeditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="width:100%; height:100%;">
 <head>
-    <title>ONLYOFFICE Visio Editor</title>
+    <title>{{APP_TITLE_TEXT}} Visio Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -11,6 +11,12 @@
     <!-- splash -->        
 
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-dark .loader-logo-light { display: none; }
+        .theme-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -273,11 +279,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                         '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                             ((logo!==null) ? logo :
-                            '<div class="loader-page-romb">' +
-                                '<div class="romb" id="blue"></div>' +
-                                '<div class="romb" id="green"></div>' +
-                                '<div class="romb" id="red"></div>' +
-                            '</div>') +
+                            '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                         '</div>' +
                         '<div class="loader-page-text">' +  customer +
                             '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/visioeditor/main/index_loader.html.deploy
+++ b/apps/visioeditor/main/index_loader.html.deploy
@@ -14,8 +14,8 @@
         .loader-logo-light,
         .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
         .loader-logo-dark { display: none; }
-        .theme-dark .loader-logo-light { display: none; }
-        .theme-dark .loader-logo-dark { display: inline-block; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
 
         .theme-dark {
             --romb-start-color: #555;
@@ -71,11 +71,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 

--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -599,6 +599,15 @@ module.exports = function(grunt) {
                     replacements: [{
                         from: /\@\@SRC_ROOT\@\@/g,
                         to: SRC_ROOT
+                    }, {
+                        from: /\{\{APP_TITLE_TEXT\}\}/g,
+                        to: _themVal(process.env.APP_TITLE_TEXT, 'app_title')
+                    }, {
+                        from: /\{\{LOADER_LOGO\}\}/g,
+                        to: function() { return '../../common/main/resources/img/header/' + (global.themeMeta.loader_logo || 'dark-logo_s.svg'); }
+                    }, {
+                        from: /\{\{LOADER_LOGO_DARK\}\}/g,
+                        to: function() { return '../../common/main/resources/img/header/' + (global.themeMeta.loader_logo_dark || 'header-logo_s.svg'); }
                     }]
                 }
             },

--- a/theme/README.md
+++ b/theme/README.md
@@ -1,0 +1,46 @@
+# Themes & branding
+
+Each subdirectory here is a theme (e.g. `euro-office`, the default). A theme supplies brand
+assets and a `meta/config.json`; branding is applied at build time, so there is no
+hard-coded brand text or logo in the editor templates.
+
+Select a theme with the `THEME` environment variable (defaults to `euro-office`).
+
+## How branding is applied
+
+`build/Gruntfile.js` loads the active theme's `meta/config.json` into `global.themeMeta`
+(`deploy-theme` task) and substitutes `{{TOKEN}}` placeholders found in the source
+templates. Image assets under `<theme>/assets/img/` are copied over the stock images last
+(`deploy-theme-images`), so any logo referenced by its deployed path automatically shows
+the active theme's brand.
+
+### Tokens substituted in editor HTML (`apps/*/main/*.html.deploy`)
+
+| Token | Resolves to | Config key (fallback) |
+|-------|-------------|-----------------------|
+| `{{APP_TITLE_TEXT}}` | `<title>` brand prefix, e.g. "Euro Office Document Editor" | `app_title` |
+| `{{LOADER_LOGO}}` | Splash logo on a light background | `loader_logo` (`dark-logo_s.svg`) |
+| `{{LOADER_LOGO_DARK}}` | Splash logo on a dark background | `loader_logo_dark` (`header-logo_s.svg`) |
+
+Logo paths resolve to `apps/common/main/resources/img/header/<file>`, which
+`deploy-theme-images` overwrites with the active theme's versions. An environment variable
+of the same name (e.g. `APP_TITLE_TEXT`) overrides the config value when set.
+
+The splash loader shows `{{LOADER_LOGO}}` by default and `{{LOADER_LOGO_DARK}}` when the
+page is in dark mode (`.theme-dark`). This replaces the upstream animated "romb" diamonds,
+which were the ONLYOFFICE logo.
+
+## Branding customization is unlocked (issue #89)
+
+Upstream gates integrator branding — `customization.loaderLogo`, `loaderName`, header
+`logo`, custom fonts — behind the commercial license (`asc_getCanBranding()`), so passing
+those options on the community build raised a "paid feature" dialog. As an AGPL fork we
+drop that license factor in each editor's `Main.js` (`appOptions.canBrandingExt`), so
+integrators can use the documented OnlyOffice branding API without the dialog.
+
+## Adding a theme / replacing assets
+
+Create `theme/<name>/` with a `meta/config.json` and `assets/` (`img/`, `less/`). Drop
+brand SVGs into `assets/img/header/`, keeping the stock filenames to avoid build changes.
+To point the splash loader at differently named files, add `loader_logo` /
+`loader_logo_dark` keys to `meta/config.json`.


### PR DESCRIPTION
Fixes #89.

- Unlocks integrator branding on the AGPL build (`customization.loaderLogo`/`loaderName`/`logo`, fonts) — no more "paid feature" dialog.
- Replaces the ONLYOFFICE splash diamonds with the theme logo (light/dark) and brands the window `<title>`.
- Build substitutes the new HTML tokens; see `theme/README.md`.

Done on the grunt branch so it ships from current `main`; the same substitution will need mirroring in `deploy-html.js` when the webpack migration lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)