### PR TITLE
🐛 fix(branding): remove ONLYOFFICE branding from loader and unlock customization (#89) — webpack mirror [PARKED]

### DIFF
--- a/apps/documenteditor/main/app/controller/Main.js
+++ b/apps/documenteditor/main/app/controller/Main.js
@@ -1791,7 +1791,7 @@ define([
 
                 this.appOptions.fileKey = this.document.key;
 
-                this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                 Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
 

--- a/apps/documenteditor/main/index.html.deploy
+++ b/apps/documenteditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/documenteditor/main/index_loader.html.deploy
+++ b/apps/documenteditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -12,6 +12,12 @@
     <!-- splash -->
 
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -66,11 +72,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 
@@ -275,11 +281,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                     '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                         ((logo!==null) ? logo :
-                        '<div class="loader-page-romb">' +
-                            '<div class="romb" id="blue"></div>' +
-                            '<div class="romb" id="green"></div>' +
-                            '<div class="romb" id="red"></div>' +
-                        '</div>') +
+                        '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                     '</div>' +
                     '<div class="loader-page-text">' +  customer +
                         '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/documenteditor/mobile/index.html
+++ b/apps/documenteditor/mobile/index.html
@@ -218,7 +218,7 @@ body.theme-type-dark {
     width: 24px;
     height: 24px;
     fill: var(--skl-toolbar-icons);
-}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.d887fab291bc8d0831c2.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'word';
+}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.b27483914a115d67cc60.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'word';
         
 const load_stylesheet = reflink => {
     let link = document.createElement( "link" );

--- a/apps/pdfeditor/main/app/controller/Main.js
+++ b/apps/pdfeditor/main/app/controller/Main.js
@@ -1398,7 +1398,7 @@ define([
 
                 this.appOptions.fileKey = this.document.key;
 
-                this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                 Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                 Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!

--- a/apps/pdfeditor/main/index.html.deploy
+++ b/apps/pdfeditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE PDF Editor</title>
+    <title>{{APP_TITLE_TEXT}} PDF Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/pdfeditor/main/index_loader.html.deploy
+++ b/apps/pdfeditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE PDF Editor</title>
+    <title>{{APP_TITLE_TEXT}} PDF Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -11,6 +11,12 @@
     <!-- splash -->
 
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -65,11 +71,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 
@@ -274,11 +280,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                     '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                         ((logo!==null) ? logo :
-                        '<div class="loader-page-romb">' +
-                            '<div class="romb" id="blue"></div>' +
-                            '<div class="romb" id="green"></div>' +
-                            '<div class="romb" id="red"></div>' +
-                        '</div>') +
+                        '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                     '</div>' +
                     '<div class="loader-page-text">' +  customer +
                         '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/presentationeditor/main/app/controller/Main.js
+++ b/apps/presentationeditor/main/app/controller/Main.js
@@ -1392,7 +1392,7 @@ define([
                     this.appOptions.canUseHistory = false;
                 }
 
-                this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                 Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
 

--- a/apps/presentationeditor/main/index.html.deploy
+++ b/apps/presentationeditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="width:100%; height:100%;">
 <head>
-    <title>ONLYOFFICE Presentation Editor</title>
+    <title>{{APP_TITLE_TEXT}} Presentation Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/presentationeditor/main/index_loader.html.deploy
+++ b/apps/presentationeditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="width:100%; height:100%;">
 <head>
-    <title>ONLYOFFICE Presentation Editor</title>
+    <title>{{APP_TITLE_TEXT}} Presentation Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -11,6 +11,12 @@
     <!-- splash -->        
 
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -65,11 +71,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 
@@ -274,11 +280,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                         '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                             ((logo!==null) ? logo :
-                            '<div class="loader-page-romb">' +
-                                '<div class="romb" id="blue"></div>' +
-                                '<div class="romb" id="green"></div>' +
-                                '<div class="romb" id="red"></div>' +
-                            '</div>') +
+                            '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                         '</div>' +
                         '<div class="loader-page-text">' +  customer +
                             '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/presentationeditor/mobile/index.html
+++ b/apps/presentationeditor/mobile/index.html
@@ -218,7 +218,7 @@ body.theme-type-dark {
     width: 24px;
     height: 24px;
     fill: var(--skl-toolbar-icons);
-}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.9c160f9d9d045320aaa4.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'slide';
+}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.cb9d9beb889fa13653f4.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'slide';
         
 const load_stylesheet = reflink => {
     let link = document.createElement( "link" );

--- a/apps/spreadsheeteditor/main/app/controller/Main.js
+++ b/apps/spreadsheeteditor/main/app/controller/Main.js
@@ -1452,7 +1452,7 @@ define([
                     this.appOptions.isBeta         = params.asc_getIsBeta();
                     this.appOptions.canModifyFilter = (this.permissions.modifyFilter!==false);
 
-                    this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                    this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                     Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                     this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                     Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!

--- a/apps/spreadsheeteditor/main/index.html.deploy
+++ b/apps/spreadsheeteditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/spreadsheeteditor/main/index_internal.html.deploy
+++ b/apps/spreadsheeteditor/main/index_internal.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/spreadsheeteditor/main/index_loader.html.deploy
+++ b/apps/spreadsheeteditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ONLYOFFICE Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Document Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -11,6 +11,12 @@
 
     <!-- splash -->
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -65,11 +71,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 
@@ -274,11 +280,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                     '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                         ((logo!==null) ? logo :
-                            '<div class="loader-page-romb">' +
-                                '<div class="romb" id="blue"></div>' +
-                                '<div class="romb" id="green"></div>' +
-                                '<div class="romb" id="red"></div>' +
-                            '</div>') +
+                            '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                     '</div>' +
                     '<div class="loader-page-text">' +  customer +
                         '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/spreadsheeteditor/mobile/index.html
+++ b/apps/spreadsheeteditor/mobile/index.html
@@ -218,7 +218,7 @@ body.theme-type-dark {
     width: 24px;
     height: 24px;
     fill: var(--skl-toolbar-icons);
-}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.9c160f9d9d045320aaa4.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'cell';
+}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.cb9d9beb889fa13653f4.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'cell';
         
 const load_stylesheet = reflink => {
     let link = document.createElement( "link" );

--- a/apps/visioeditor/main/app/controller/Main.js
+++ b/apps/visioeditor/main/app/controller/Main.js
@@ -1189,7 +1189,7 @@ define([
                     this.appOptions.canUseHistory = false;
                 }
 
-                this.appOptions.canBrandingExt = params.asc_getCanBranding() && (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
+                this.appOptions.canBrandingExt = (typeof this.editorConfig.customization == 'object' || this.editorConfig.plugins);
                 Common.UI.LayoutManager.init(this.editorConfig.customization ? this.editorConfig.customization.layout : null, this.appOptions.canBrandingExt, this.api);
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                 Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!

--- a/apps/visioeditor/main/index.html.deploy
+++ b/apps/visioeditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="width:100%; height:100%;">
 <head>
-    <title>ONLYOFFICE Visio Editor</title>
+    <title>{{APP_TITLE_TEXT}} Visio Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/visioeditor/main/index_loader.html.deploy
+++ b/apps/visioeditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="width:100%; height:100%;">
 <head>
-    <title>ONLYOFFICE Visio Editor</title>
+    <title>{{APP_TITLE_TEXT}} Visio Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -11,6 +11,12 @@
     <!-- splash -->        
 
     <style type="text/css">
+        .loader-logo-light,
+        .loader-logo-dark { width: 240px; max-width: 80%; height: auto; vertical-align: middle; }
+        .loader-logo-dark { display: none; }
+        .theme-type-dark .loader-logo-light { display: none; }
+        .theme-type-dark .loader-logo-dark { display: inline-block; }
+
         .theme-dark {
             --romb-start-color: #555;
         }
@@ -65,11 +71,11 @@
             margin-bottom: 5px;
         }
 
-        .theme-dark .loadmask {
+        .theme-type-dark .loadmask {
             background-color: #555;
         }
 
-        .theme-dark .loader-page-text {
+        .theme-type-dark .loader-page-text {
             color: rgba(255, 255, 255, 0.8);
         }
 
@@ -273,11 +279,8 @@
                 '<div id="loading-mask" class="loadmask">' +
                         '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                             ((logo!==null) ? logo :
-                            '<div class="loader-page-romb">' +
-                                '<div class="romb" id="blue"></div>' +
-                                '<div class="romb" id="green"></div>' +
-                                '<div class="romb" id="red"></div>' +
-                            '</div>') +
+                            '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
+                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                         '</div>' +
                         '<div class="loader-page-text">' +  customer +
                             '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/visioeditor/mobile/index.html
+++ b/apps/visioeditor/mobile/index.html
@@ -218,7 +218,7 @@ body.theme-type-dark {
     width: 24px;
     height: 24px;
     fill: var(--skl-toolbar-icons);
-}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.9c160f9d9d045320aaa4.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'visio';
+}</style><script defer="defer" src="dist/js/app.js"></script><link href="css/app.cb9d9beb889fa13653f4.css" rel="stylesheet"></head><body><script>window.Common = {Locale: {defaultLang: "en"}};</script><script>window.asceditor = 'visio';
         
 const load_stylesheet = reflink => {
     let link = document.createElement( "link" );

--- a/build/scripts/deploy-html.js
+++ b/build/scripts/deploy-html.js
@@ -41,6 +41,25 @@ const SRC_ROOT = REPO_ROOT;
 const APPS_SRC = path.join(REPO_ROOT, 'apps');
 const APPS_OUT = path.join(BUILD_ROOT, 'web-apps', 'apps');
 
+// Theme branding tokens (issue #89) — mirrors grunt replace:indexhtml. Env vars override
+// theme config.json; logo paths resolve to the header logos deploy-theme-images overwrites.
+const THEME = process.env.THEME || 'default';
+let themeMeta = {};
+{
+    const cfg = path.join(REPO_ROOT, 'theme', THEME, 'meta', 'config.json');
+    if (fs.existsSync(cfg)) {
+        try { themeMeta = JSON.parse(fs.readFileSync(cfg, 'utf8')); }
+        catch (e) { console.warn(`deploy-html: bad theme config ${cfg}: ${e.message}`); }
+    }
+}
+const tv = (envVal, key, def) => (envVal != null && envVal !== '') ? envVal : (key in themeMeta ? themeMeta[key] : def);
+const HEADER_IMG = '../../common/main/resources/img/header/';
+const TOKENS = {
+    APP_TITLE_TEXT:   tv(process.env.APP_TITLE_TEXT, 'app_title', 'ONLYOFFICE'),
+    LOADER_LOGO:      HEADER_IMG + (themeMeta.loader_logo || 'dark-logo_s.svg'),
+    LOADER_LOGO_DARK: HEADER_IMG + (themeMeta.loader_logo_dark || 'header-logo_s.svg'),
+};
+
 const DIRS = [
     { editor: 'documenteditor',     subpath: 'main'  },
     { editor: 'spreadsheeteditor',  subpath: 'main'  },
@@ -73,7 +92,8 @@ for (const { editor, subpath } of DIRS) {
 
     for (const filename of deploys) {
         const content  = fs.readFileSync(path.join(srcDir, filename), 'utf8');
-        const replaced = content.replace(/@@SRC_ROOT@@/g, SRC_ROOT);
+        let replaced   = content.replace(/@@SRC_ROOT@@/g, SRC_ROOT);
+        for (const [k, v] of Object.entries(TOKENS)) replaced = replaced.split(`{{${k}}}`).join(v);
         const destName = filename.replace('.html.deploy', '.html');
         fs.writeFileSync(path.join(destDir, destName), replaced, 'utf8');
     }

--- a/build/scripts/verify-bundles.mjs
+++ b/build/scripts/verify-bundles.mjs
@@ -66,7 +66,8 @@ let failed = false;
 
 for (const bundle of BUNDLES) {
     if (!fs.existsSync(bundle.path)) {
-        console.warn(`verify-bundles: skip  ${bundle.label}  (not found — build may not have run)`);
+        console.error(`verify-bundles: FAIL  ${bundle.label}  (not found — webpack did not emit this bundle)`);
+        failed = true;
         continue;
     }
     const content = fs.readFileSync(bundle.path, 'utf8');

--- a/build/webpack.editor.factory.mjs
+++ b/build/webpack.editor.factory.mjs
@@ -98,7 +98,13 @@ export function editorConfig(editorName, opts = {}) {
             filename: '[name].js',
             chunkFilename: '[name].chunk.js',
             publicPath: '',
+            // clean:false is intentional — all six editors share BUILD_ROOT; wiping it would
+            // destroy sibling editors' output. Safe only because the output set is fixed
+            // ([name].js, [name].css, locale/*). Do not enable splitChunks or dynamic import()
+            // without also adding per-editor output cleaning or content-hashed filenames —
+            // a build that stops emitting a chunk leaves a stale file the SW will cache.
             clean: false,
+            // asyncChunks:false keeps all AMD require() calls bundled synchronously.
             asyncChunks: false,
         },
 
@@ -233,6 +239,8 @@ export function editorConfig(editorName, opts = {}) {
         ],
 
         optimization: {
+            // splitChunks:false — see clean:false note above. Enabling this without
+            // content-hashed filenames or per-editor cleaning leaves stale chunks on disk.
             splitChunks: false,
             minimize: env === 'production',
             minimizer: [

--- a/docs/webpack-migration.md
+++ b/docs/webpack-migration.md
@@ -131,9 +131,17 @@ The common `index.html` also has inline tags. If `inline-svgs.js` only covers ed
 
 Always test in incognito or disable the SW in DevTools → Application → Service Workers. Stale `app.js` from a previous build will persist invisibly. Two `app.js` entries in DevTools Sources = cache conflict.
 
-### 9. `output.clean: false` is intentional
+**Why incognito is needed locally (not in production):** The production server 302-redirects every asset through a version-prefixed URL (`/<PRODUCT_VERSION>-<cache_tag>/…`), and `cache_tag` is a fresh random hash per deploy (`documentserver-flush-cache.sh`). Real production deploys self-bust the SW with no manual action.
+
+Locally, the `eo` Makefile pins `PRODUCT_VERSION` from a static `VERSION` file. A local `make web-apps` rebuild emits a new `app.js` at the **same URL** — same version prefix, no `cache_tag` change — so the SW recognises the path as a known asset and serves the previous (stale) bundle from its cache.
+
+Fix: run `documentserver-flush-cache.sh` inside the container after a local rebuild, or use incognito for the test session.
+
+### 9. `output.clean: false` is intentional — do not enable code-splitting without also addressing stale chunks
 
 All six webpack configs share a single `BUILD_ROOT`. Setting `clean: true` would wipe sibling editors' output. Leave it false.
+
+This is safe **only because the output set is fixed**: each editor always emits exactly `app.js`, `app.css`, and `locale/*`. Do not enable `splitChunks`, dynamic `import()`, or `asyncChunks` without adding per-editor output cleaning or content-hashed filenames. A build that stops emitting a chunk would leave the old file on disk; the SW would cache it under the live version prefix and serve stale code silently.
 
 ---
 


### PR DESCRIPTION
**Parked.** Webpack mirror of #139 (which lands the same fix on the grunt `main` line). Same source edits as #139 — `Main.js` gate unlock + `.deploy` loader logo/title — with the build wiring expressed for webpack: `deploy-html.js` now substitutes `{{APP_TITLE_TEXT}}`/`{{LOADER_LOGO}}`/`{{LOADER_LOGO_DARK}}` (mirrors grunt's `replace:indexhtml`).

Verified with `make web-apps-dev` (incl. mobile): splash logo correct in light + dark, title branded.

Held until the webpack migration lands; will be rebased/updated as the pipeline evolves. Docs (`theme/README.md`) intentionally live on #139 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)