### PR TITLE
🐛 fix(branding): extend unlock to mobile and clean up loader templates (#89)

### DIFF
--- a/apps/documenteditor/main/index_loader.html.deploy
+++ b/apps/documenteditor/main/index_loader.html.deploy
@@ -18,10 +18,6 @@
         .theme-type-dark .loader-logo-light { display: none; }
         .theme-type-dark .loader-logo-dark { display: inline-block; }
 
-        .theme-dark {
-            --romb-start-color: #555;
-        }
-
         .loadmask {
             left: 0;
             top: 0;
@@ -46,11 +42,6 @@
         .loader-logo {
             max-height: 160px;
             margin-bottom: 10px;
-        }
-
-        .loader-page-romb {
-            width: 40px;
-            display: inline-block;
         }
 
         .loader-page-text {
@@ -80,120 +71,6 @@
             color: rgba(255, 255, 255, 0.8);
         }
 
-        .romb {
-            width: 40px;
-            height: 40px;
-            -webkit-transform: rotate(135deg) skew(20deg, 20deg);
-            -moz-transform: rotate(135deg) skew(20deg, 20deg);
-            -ms-transform: rotate(135deg) skew(20deg, 20deg);
-            -o-transform: rotate(135deg) skew(20deg, 20deg);
-            position: absolute;
-            background: red;
-            border-radius: 6px;
-            -webkit-animation: movedown 3s infinite ease;
-            -moz-animation: movedown 3s infinite ease;
-            -ms-animation: movedown 3s infinite ease;
-            -o-animation: movedown 3s infinite ease;
-            animation: movedown 3s infinite ease;
-        }
-
-        #blue {
-            z-index: 3;
-            background: #55bce6;
-            -webkit-animation-name: blue;
-            -moz-animation-name: blue;
-            -ms-animation-name: blue;
-            -o-animation-name: blue;
-            animation-name: blue;
-        }
-
-        #red {
-            z-index:1;
-            background: #de7a59;
-            -webkit-animation-name: red;
-            -moz-animation-name: red;
-            -ms-animation-name: red;
-            -o-animation-name: red;
-            animation-name: red;
-        }
-
-        #green {
-            z-index: 2;
-            background: #a1cb5c;
-            -webkit-animation-name: green;
-            -moz-animation-name: green;
-            -ms-animation-name: green;
-            -o-animation-name: green;
-            animation-name: green;
-        }
-
-        @-webkit-keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @-webkit-keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @-webkit-keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
-
-        @keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
     </style>
 
     <script>

--- a/apps/documenteditor/mobile/src/store/appOptions.js
+++ b/apps/documenteditor/mobile/src/store/appOptions.js
@@ -232,7 +232,7 @@ export class storeAppOptions {
         this.canReader = (!type || typeof type[1] !== 'string');
 
         this.canBranding = params.asc_getCustomization();
-        this.canBrandingExt = params.asc_getCanBranding() && (typeof this.customization == 'object' || this.config.plugins);
+        this.canBrandingExt = (typeof this.customization == 'object' || this.config.plugins);
 
         this.canFavorite = document.info && (document.info?.favorite !== undefined && document.info?.favorite !== null) && !this.isOffline;
         this.isFavorite = document.info?.favorite;

--- a/apps/pdfeditor/main/index_loader.html.deploy
+++ b/apps/pdfeditor/main/index_loader.html.deploy
@@ -17,10 +17,6 @@
         .theme-type-dark .loader-logo-light { display: none; }
         .theme-type-dark .loader-logo-dark { display: inline-block; }
 
-        .theme-dark {
-            --romb-start-color: #555;
-        }
-
         .loadmask {
             left: 0;
             top: 0;
@@ -45,11 +41,6 @@
         .loader-logo {
             max-height: 160px;
             margin-bottom: 10px;
-        }
-
-        .loader-page-romb {
-            width: 40px;
-            display: inline-block;
         }
 
         .loader-page-text {
@@ -79,120 +70,6 @@
             color: rgba(255, 255, 255, 0.8);
         }
 
-        .romb {
-            width: 40px;
-            height: 40px;
-            -webkit-transform: rotate(135deg) skew(20deg, 20deg);
-            -moz-transform: rotate(135deg) skew(20deg, 20deg);
-            -ms-transform: rotate(135deg) skew(20deg, 20deg);
-            -o-transform: rotate(135deg) skew(20deg, 20deg);
-            position: absolute;
-            background: red;
-            border-radius: 6px;
-            -webkit-animation: movedown 3s infinite ease;
-            -moz-animation: movedown 3s infinite ease;
-            -ms-animation: movedown 3s infinite ease;
-            -o-animation: movedown 3s infinite ease;
-            animation: movedown 3s infinite ease;
-        }
-
-        #blue {
-            z-index: 3;
-            background: #55bce6;
-            -webkit-animation-name: blue;
-            -moz-animation-name: blue;
-            -ms-animation-name: blue;
-            -o-animation-name: blue;
-            animation-name: blue;
-        }
-
-        #red {
-            z-index:1;
-            background: #de7a59;
-            -webkit-animation-name: red;
-            -moz-animation-name: red;
-            -ms-animation-name: red;
-            -o-animation-name: red;
-            animation-name: red;
-        }
-
-        #green {
-            z-index: 2;
-            background: #a1cb5c;
-            -webkit-animation-name: green;
-            -moz-animation-name: green;
-            -ms-animation-name: green;
-            -o-animation-name: green;
-            animation-name: green;
-        }
-
-        @-webkit-keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @-webkit-keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @-webkit-keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
-
-        @keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
     </style>
 
     <script>

--- a/apps/presentationeditor/main/index_loader.html.deploy
+++ b/apps/presentationeditor/main/index_loader.html.deploy
@@ -17,10 +17,6 @@
         .theme-type-dark .loader-logo-light { display: none; }
         .theme-type-dark .loader-logo-dark { display: inline-block; }
 
-        .theme-dark {
-            --romb-start-color: #555;
-        }
-
         .loadmask {
             left: 0;
             top: 0;
@@ -45,11 +41,6 @@
         .loader-logo {
             max-height: 160px;
             margin-bottom: 10px;
-        }
-
-        .loader-page-romb {
-            width: 40px;
-            display: inline-block;
         }
 
         .loader-page-text {
@@ -79,120 +70,6 @@
             color: rgba(255, 255, 255, 0.8);
         }
 
-        .romb {
-            width: 40px;
-            height: 40px;
-            -webkit-transform: rotate(135deg) skew(20deg, 20deg);
-            -moz-transform: rotate(135deg) skew(20deg, 20deg);
-            -ms-transform: rotate(135deg) skew(20deg, 20deg);
-            -o-transform: rotate(135deg) skew(20deg, 20deg);
-            position: absolute;
-            background: red;
-            border-radius: 6px;
-            -webkit-animation: movedown 3s infinite ease;
-            -moz-animation: movedown 3s infinite ease;
-            -ms-animation: movedown 3s infinite ease;
-            -o-animation: movedown 3s infinite ease;
-            animation: movedown 3s infinite ease;
-        }
-
-        #blue {
-            z-index: 3;
-            background: #55bce6;
-            -webkit-animation-name: blue;
-            -moz-animation-name: blue;
-            -ms-animation-name: blue;
-            -o-animation-name: blue;
-            animation-name: blue;
-        }
-
-        #red {
-            z-index:1;
-            background: #de7a59;
-            -webkit-animation-name: red;
-            -moz-animation-name: red;
-            -ms-animation-name: red;
-            -o-animation-name: red;
-            animation-name: red;
-        }
-
-        #green {
-            z-index: 2;
-            background: #a1cb5c;
-            -webkit-animation-name: green;
-            -moz-animation-name: green;
-            -ms-animation-name: green;
-            -o-animation-name: green;
-            animation-name: green;
-        }
-
-        @-webkit-keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @-webkit-keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @-webkit-keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
-
-        @keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
     </style>
 
     <script>
@@ -281,7 +158,7 @@
                         '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                             ((logo!==null) ? logo :
                             '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
-                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
+                            '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                         '</div>' +
                         '<div class="loader-page-text">' +  customer +
                             '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/presentationeditor/mobile/src/store/appOptions.js
+++ b/apps/presentationeditor/mobile/src/store/appOptions.js
@@ -149,7 +149,7 @@ export class storeAppOptions {
         this.canDownload = permissions.download !== false && (!type || typeof type[1] !== 'string');
 
         this.canBranding = params.asc_getCustomization();
-        this.canBrandingExt = params.asc_getCanBranding() && (typeof this.customization == 'object' || this.config.plugins);
+        this.canBrandingExt = (typeof this.customization == 'object' || this.config.plugins);
 
         this.canUseReviewPermissions = this.canLicense && (!!permissions.reviewGroups || this.customization 
             && this.customization.reviewPermissions && (typeof (this.customization.reviewPermissions) == 'object'));

--- a/apps/spreadsheeteditor/main/index.html.deploy
+++ b/apps/spreadsheeteditor/main/index.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{{APP_TITLE_TEXT}} Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Spreadsheet Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/spreadsheeteditor/main/index_internal.html.deploy
+++ b/apps/spreadsheeteditor/main/index_internal.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{{APP_TITLE_TEXT}} Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Spreadsheet Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />

--- a/apps/spreadsheeteditor/main/index_loader.html.deploy
+++ b/apps/spreadsheeteditor/main/index_loader.html.deploy
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{{APP_TITLE_TEXT}} Document Editor</title>
+    <title>{{APP_TITLE_TEXT}} Spreadsheet Editor</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=IE8"/>
     <meta name="description" content="" />
@@ -16,10 +16,6 @@
         .loader-logo-dark { display: none; }
         .theme-type-dark .loader-logo-light { display: none; }
         .theme-type-dark .loader-logo-dark { display: inline-block; }
-
-        .theme-dark {
-            --romb-start-color: #555;
-        }
 
         .loadmask {
             left: 0;
@@ -45,11 +41,6 @@
         .loader-logo {
             max-height: 160px;
             margin-bottom: 10px;
-        }
-
-        .loader-page-romb {
-            width: 40px;
-            display: inline-block;
         }
 
         .loader-page-text {
@@ -79,120 +70,6 @@
             color: rgba(255, 255, 255, 0.8);
         }
 
-        .romb {
-            width: 40px;
-            height: 40px;
-            -webkit-transform: rotate(135deg) skew(20deg, 20deg);
-            -moz-transform: rotate(135deg) skew(20deg, 20deg);
-            -ms-transform: rotate(135deg) skew(20deg, 20deg);
-            -o-transform: rotate(135deg) skew(20deg, 20deg);
-            position: absolute;
-            background: red;
-            border-radius: 6px;
-            -webkit-animation: movedown 3s infinite ease;
-            -moz-animation: movedown 3s infinite ease;
-            -ms-animation: movedown 3s infinite ease;
-            -o-animation: movedown 3s infinite ease;
-            animation: movedown 3s infinite ease;
-        }
-
-        #blue {
-            z-index: 3;
-            background: #55bce6;
-            -webkit-animation-name: blue;
-            -moz-animation-name: blue;
-            -ms-animation-name: blue;
-            -o-animation-name: blue;
-            animation-name: blue;
-        }
-
-        #red {
-            z-index:1;
-            background: #de7a59;
-            -webkit-animation-name: red;
-            -moz-animation-name: red;
-            -ms-animation-name: red;
-            -o-animation-name: red;
-            animation-name: red;
-        }
-
-        #green {
-            z-index: 2;
-            background: #a1cb5c;
-            -webkit-animation-name: green;
-            -moz-animation-name: green;
-            -ms-animation-name: green;
-            -o-animation-name: green;
-            animation-name: green;
-        }
-
-        @-webkit-keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @-webkit-keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @-webkit-keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
-
-        @keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
     </style>
 
     <script>
@@ -281,7 +158,7 @@
                     '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                         ((logo!==null) ? logo :
                             '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
-                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
+                            '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                     '</div>' +
                     '<div class="loader-page-text">' +  customer +
                         '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/spreadsheeteditor/mobile/src/store/appOptions.js
+++ b/apps/spreadsheeteditor/mobile/src/store/appOptions.js
@@ -116,7 +116,7 @@ export class storeAppOptions {
         if (params.asc_getRights() !== Asc.c_oRights.Edit)
             permissions.edit = false;
         this.canBranding = params.asc_getCustomization();
-        this.canBrandingExt = params.asc_getCanBranding() && (typeof this.customization == 'object' || this.config.plugins);
+        this.canBrandingExt = (typeof this.customization == 'object' || this.config.plugins);
         this.canModifyFilter = permissions.modifyFilter !== false;
         this.canAutosave = true;
         this.canAnalytics = params.asc_getIsAnalyticsEnable();

--- a/apps/visioeditor/main/index_loader.html.deploy
+++ b/apps/visioeditor/main/index_loader.html.deploy
@@ -17,10 +17,6 @@
         .theme-type-dark .loader-logo-light { display: none; }
         .theme-type-dark .loader-logo-dark { display: inline-block; }
 
-        .theme-dark {
-            --romb-start-color: #555;
-        }
-
         .loadmask {
             left: 0;
             top: 0;
@@ -45,11 +41,6 @@
         .loader-logo {
             max-height: 160px;
             margin-bottom: 10px;
-        }
-
-        .loader-page-romb {
-            width: 40px;
-            display: inline-block;
         }
 
         .loader-page-text {
@@ -79,120 +70,6 @@
             color: rgba(255, 255, 255, 0.8);
         }
 
-        .romb {
-            width: 40px;
-            height: 40px;
-            -webkit-transform: rotate(135deg) skew(20deg, 20deg);
-            -moz-transform: rotate(135deg) skew(20deg, 20deg);
-            -ms-transform: rotate(135deg) skew(20deg, 20deg);
-            -o-transform: rotate(135deg) skew(20deg, 20deg);
-            position: absolute;
-            background: red;
-            border-radius: 6px;
-            -webkit-animation: movedown 3s infinite ease;
-            -moz-animation: movedown 3s infinite ease;
-            -ms-animation: movedown 3s infinite ease;
-            -o-animation: movedown 3s infinite ease;
-            animation: movedown 3s infinite ease;
-        }
-
-        #blue {
-            z-index: 3;
-            background: #55bce6;
-            -webkit-animation-name: blue;
-            -moz-animation-name: blue;
-            -ms-animation-name: blue;
-            -o-animation-name: blue;
-            animation-name: blue;
-        }
-
-        #red {
-            z-index:1;
-            background: #de7a59;
-            -webkit-animation-name: red;
-            -moz-animation-name: red;
-            -ms-animation-name: red;
-            -o-animation-name: red;
-            animation-name: red;
-        }
-
-        #green {
-            z-index: 2;
-            background: #a1cb5c;
-            -webkit-animation-name: green;
-            -moz-animation-name: green;
-            -ms-animation-name: green;
-            -o-animation-name: green;
-            animation-name: green;
-        }
-
-        @-webkit-keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @keyframes red {
-              0%    { top:120px; background: #de7a59; }
-             10%    { top:120px; background: #F2CBBF; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:120px; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0;}
-             20%    { background: #E6E4E4; }
-             30%    { background: #D2D2D2; }
-             40%    { top:120px; }
-            100%    { top:120px; background: #de7a59; }
-        }
-
-        @-webkit-keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @keyframes green {
-              0%    { top:110px; background: #a1cb5c; opacity:1; }
-             10%    { top:110px; background: #CBE0AC; opacity:1; }
-             14%    { background: #f4f4f4; top:110px; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             15%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:1; }
-             20%    { background: #f4f4f4; top:0; background: var(--romb-start-color,#f4f4f4); opacity:0; }
-             25%    { background: #EFEFEF; top:0; opacity:1; }
-             30%    { background:#E6E4E4; }
-             70%    { top:110px; }
-            100%    { top:110px; background: #a1cb5c; }
-        }
-
-        @-webkit-keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
-
-        @keyframes blue {
-              0%    { top:100px; background: #55bce6; opacity:1; }
-             10%    { top:100px; background: #BFE8F8; opacity:1; }
-             14%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:100px; opacity:1; }
-             15%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:1; }
-             20%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             25%    { background: #f4f4f4; background: var(--romb-start-color,#f4f4f4); top:0; opacity:0; }
-             45%    { background: #EFEFEF; top:0; opacity:0.2; }
-            100%    { top:100px; background: #55bce6; }
-        }
     </style>
 
     <script>
@@ -280,7 +157,7 @@
                         '<div class="loader-page" style="margin-bottom: ' + margin + 'px;' + ((logo!==null) ? 'height: auto;' : '') + '">' +
                             ((logo!==null) ? logo :
                             '<img class="loader-logo loader-logo-light" src="{{LOADER_LOGO}}" />' +
-                        '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
+                            '<img class="loader-logo loader-logo-dark" src="{{LOADER_LOGO_DARK}}" />') +
                         '</div>' +
                         '<div class="loader-page-text">' +  customer +
                             '<div class="loader-page-text-loading">' + loading + '</div>' +

--- a/apps/visioeditor/mobile/src/store/appOptions.js
+++ b/apps/visioeditor/mobile/src/store/appOptions.js
@@ -139,7 +139,7 @@ export class storeAppOptions {
         this.canDownload = permissions.download !== false;
 
         this.canBranding = params.asc_getCustomization();
-        this.canBrandingExt = params.asc_getCanBranding() && (typeof this.customization == 'object' || this.config.plugins);
+        this.canBrandingExt = (typeof this.customization == 'object' || this.config.plugins);
 
         this.canUseReviewPermissions = this.canLicense && (!!permissions.reviewGroups || this.customization 
             && this.customization.reviewPermissions && (typeof (this.customization.reviewPermissions) == 'object'));

--- a/theme/README.md
+++ b/theme/README.md
@@ -24,18 +24,20 @@ the active theme's brand.
 
 Logo paths resolve to `apps/common/main/resources/img/header/<file>`, which
 `deploy-theme-images` overwrites with the active theme's versions. An environment variable
-of the same name (e.g. `APP_TITLE_TEXT`) overrides the config value when set.
+of the same name (e.g. `APP_TITLE_TEXT`) overrides the config value when set. **Note:**
+`loader_logo` and `loader_logo_dark` are config-file-only keys — they have no env-var
+override path.
 
 The splash loader shows `{{LOADER_LOGO}}` by default and `{{LOADER_LOGO_DARK}}` when the
-page is in dark mode (`.theme-dark`). This replaces the upstream animated "romb" diamonds,
-which were the ONLYOFFICE logo.
+page is in dark mode (`.theme-type-dark`). This replaces the upstream animated "romb"
+diamonds, which were the ONLYOFFICE logo.
 
 ## Branding customization is unlocked (issue #89)
 
 Upstream gates integrator branding — `customization.loaderLogo`, `loaderName`, header
 `logo`, custom fonts — behind the commercial license (`asc_getCanBranding()`), so passing
 those options on the community build raised a "paid feature" dialog. As an AGPL fork we
-drop that license factor in each editor's `Main.js` (`appOptions.canBrandingExt`), so
+drop that license factor in each editor's `Main.js` and mobile `appOptions.js` (`appOptions.canBrandingExt`), so
 integrators can use the documented OnlyOffice branding API without the dialog.
 
 ## Adding a theme / replacing assets


### PR DESCRIPTION
Follow-up to #139 (merged).

## Summary

- **Mobile branding unlock**: drop `asc_getCanBranding()` from `canBrandingExt` in all four mobile `appOptions.js` stores — without this, mobile builds still raised the "paid feature" dialog for integrator branding while desktop did not
- **Dead romb CSS**: remove `.romb`, `.loader-page-romb`, `#blue/#red/#green` and all `@keyframes` from all five `index_loader.html.deploy` files (~120 lines per file; the romb HTML was already removed in #139)
- **Spreadsheeteditor titles**: fix pre-existing copy-paste error — `index.html`, `index_loader.html`, and `index_internal.html` all said "Document Editor" instead of "Spreadsheet Editor"
- **Indentation**: align `loader-logo-dark` img tag in presentation/spreadsheet/visio loaders to match doc and pdf
- **README**: note that `loader_logo`/`loader_logo_dark` are config-file-only keys; fix `.theme-dark` → `.theme-type-dark`; mention mobile stores

## Test plan

- [ ] Mobile editor loads without "paid feature" dialog when `customization` object is present in editor config
- [ ] Spreadsheet editor browser tab shows "… Spreadsheet Editor" not "… Document Editor"
- [ ] Splash loader renders correctly in light and dark mode (no romb CSS regression — elements were already removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)