### PR TITLE
mobile: change add button icon on toolbar

### DIFF
--- a/apps/common/mobile/lib/editor.jsx
+++ b/apps/common/mobile/lib/editor.jsx
@@ -3,8 +3,8 @@ import { Device } from '../utils/device';
 import SvgIcon from './component/SvgIcon';
 import IconEditSettingsIos from '@common-ios-icons/icon-edit-settings.svg?ios';
 import IconEditSettingsAndroid from '@common-android-icons/icon-edit-settings.svg';
-import IconAddOtherIos from '@common-ios-icons/icon-add-other.svg?ios';
-import IconAddOtherAndroid from '@common-android-icons/icon-add-other.svg';
+import IconPlusIos from '@common-ios-icons/icon-plus.svg?ios';
+import IconPlusAndroid from '@common-android-icons/icon-plus.svg';
 import IconUndoIos from '@common-ios-icons/icon-undo.svg?ios';
 import IconUndoAndroid from '@common-android-icons/icon-undo.svg';
 import IconRedoIos from '@common-ios-icons/icon-redo.svg?ios';
@@ -12,7 +12,7 @@ import IconRedoAndroid from '@common-android-icons/icon-redo.svg';
 
 export const icons = {
     edit: { ios: IconEditSettingsIos, android: IconEditSettingsAndroid },
-    add: { ios: IconAddOtherIos, android: IconAddOtherAndroid },
+    add: { ios: IconPlusIos, android: IconPlusAndroid },
     undo: { ios: IconUndoIos, android: IconUndoAndroid },
     redo: { ios: IconRedoIos, android: IconRedoAndroid },
 };


### PR DESCRIPTION
Simple change, uses the `add-plus` icon available on Android and iOS for the add button that's on the toolbar for all editors.
It makes more sense for me given the context. 

Here's a before/after on Android:   
Before: 
<img width="532" height="242" alt="image" src="https://github.com/user-attachments/assets/c82a20bc-13e7-4551-88b5-b88675013fd3" />


After: 
<img width="444" height="242" alt="Screenshot_20260626_160112" src="https://github.com/user-attachments/assets/2b9ed0c9-9bb5-4c87-84e7-87e71bea41a1" />