### PR TITLE
fix(docker): replace grunt with build-pipeline.js in web-apps Dockerfile

### DIFF
--- a/.docker/web-apps.bake.Dockerfile
+++ b/.docker/web-apps.bake.Dockerfile
@@ -13,7 +13,7 @@ FROM ubuntu:24.04 AS web-base
         apt-get install -y ca-certificates curl gnupg openjdk-21-jdk wget zip brotli bzip2 && \
         curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
         apt-get install -y nodejs && \
-        npm install -g @yao-pkg/pkg grunt-cli && \
+        npm install -g @yao-pkg/pkg && \
         rm -rf /var/lib/apt/lists/*
 
 #### WEB-APPS ####
@@ -22,13 +22,10 @@ FROM web-base AS web-apps
     ARG BUILD_ROOT=/package
 
     COPY web-apps/build/package*.json /app/build/
-    COPY web-apps/build/sprites/package*.json /app/build/sprites/
-    COPY web-apps/build/plugins/grunt-inline/ /app/build/plugins/grunt-inline/
 
     RUN --mount=type=cache,target=/root/.npm \
         cd app/build && \
         npm install
-
 
     COPY web-apps/ /app
 
@@ -38,6 +35,6 @@ FROM web-base AS web-apps
     RUN cd app/translation && \
         python3 merge_and_check.py
 
-    ARG TARGETARCH
     RUN cd app/build && \
-        THEME=euro-office grunt $(if [ "$TARGETARCH" = "arm64" ]; then echo "--skip-imagemin"; fi)
+        BUILD_ROOT=${BUILD_ROOT} PRODUCT_VERSION=${PRODUCT_VERSION} THEME=euro-office \
+        node scripts/build-pipeline.js


### PR DESCRIPTION
## Summary

- Removes references to `build/sprites/` and `build/plugins/grunt-inline/` — both deleted by the webpack migration (#109)
- Removes `grunt-cli` from the base image global install — no Gruntfile to run
- Replaces the `grunt` RUN step with `node scripts/build-pipeline.js`, matching what CI now does

## Root cause

PR #109 (webpack migration) deleted `build/Gruntfile.js` and `build/sprites/` but did not update `.docker/web-apps.bake.Dockerfile`. The Docker build failed immediately on the `COPY web-apps/build/sprites/package*.json` line because that directory no longer exists.

## Test plan

- [ ] DS Docker build (`docker-bake`) succeeds with updated web-apps pointer
- [ ] All 6 editors load in the resulting image

🤖 Generated with [Claude Code](https://claude.com/claude-code)