### PR TITLE
Browser-floor cleanup: drop legacy polyfills + modernise wheel/scroll

### DIFF
--- a/apps/common/main/lib/component/TabBar.js
+++ b/apps/common/main/lib/component/TabBar.js
@@ -344,10 +344,12 @@ define([
         },
 
         _onMouseWheelThrottled: function(e) {
-            var delta = e.deltaY !== undefined
+            var rawDelta = e.deltaY !== undefined
                 ? -(e.deltaMode === 1 ? e.deltaY * 30 : e.deltaY)
                 : ((e.detail && -e.detail) || e.wheelDelta);
-            if (Math.abs(delta) < 10) {
+
+            this._wheelAccum = (this._wheelAccum || 0) + rawDelta;
+            if (Math.abs(this._wheelAccum) < 10) {
                 return;
             }
 
@@ -356,6 +358,9 @@ define([
                 return;
             }
             this._lastWheelTime = now;
+
+            var delta = this._wheelAccum;
+            this._wheelAccum = 0;
 
             var hidden = this.checkInvisible(true);
 

--- a/apps/common/main/lib/component/TabBar.js
+++ b/apps/common/main/lib/component/TabBar.js
@@ -295,12 +295,7 @@ define([
                 elem.addEventListener ? elem.addEventListener( type, fn, false ) : elem.attachEvent( "on" + type, fn );
             };
 
-            if (Common.Utils.isMac) {
-                this.$bar[0].addEventListener('wheel', _.bind(this._onMouseWheelThrottled, this));
-            } else {
-                var eventname=(/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
-                addEvent(this.$bar[0], eventname, _.bind(this._onMouseWheel,this));
-            }
+            this.$bar[0].addEventListener('wheel', _.bind(this._onMouseWheelThrottled, this));
             addEvent(this.$bar[0], 'dragstart', _.bind(function (event) {
                 event.dataTransfer.effectAllowed = 'copyMove';
             }, this));
@@ -365,7 +360,9 @@ define([
         },
 
         _onMouseWheelThrottled: function(e) {
-            var delta = (e.detail && -e.detail) || e.wheelDelta;
+            var delta = e.deltaY !== undefined
+                ? -(e.deltaMode === 1 ? e.deltaY * 30 : e.deltaY)
+                : ((e.detail && -e.detail) || e.wheelDelta);
             if (Math.abs(delta) < 10) {
                 return;
             }

--- a/apps/common/main/lib/component/TabBar.js
+++ b/apps/common/main/lib/component/TabBar.js
@@ -343,22 +343,6 @@ define([
             return this;
         },
 
-        _onMouseWheel: function(e) {
-            var hidden  = this.checkInvisible(true),
-                forward = ((e.detail && -e.detail) || e.wheelDelta) < 0;
-
-            if (forward) {
-                if (hidden.last) {
-                    this.setTabVisible('forward');
-                }
-            } else {
-                if (hidden.first) {
-                    this.setTabVisible('backward');
-                }
-            }
-            Common.NotificationCenter.trigger('hints:clear');
-        },
-
         _onMouseWheelThrottled: function(e) {
             var delta = e.deltaY !== undefined
                 ? -(e.deltaMode === 1 ? e.deltaY * 30 : e.deltaY)

--- a/apps/documenteditor/main/app/controller/DocumentHolder.js
+++ b/apps/documenteditor/main/app/controller/DocumentHolder.js
@@ -381,10 +381,7 @@ define([
                 me._isScrolling = false;
             }, 100);
 
-            var delta = (_.isUndefined(event.originalEvent)) ? event.wheelDelta : event.originalEvent.wheelDelta;
-            if (_.isUndefined(delta)) {
-                delta = event.deltaY;
-            }
+            var delta = event.deltaY !== undefined ? -event.deltaY : event.wheelDelta;
 
             if (me._ctrlPressedAtScrollStart && !event.altKey) {
                 if (delta < 0) {

--- a/apps/documenteditor/main/app/controller/DocumentHolder.js
+++ b/apps/documenteditor/main/app/controller/DocumentHolder.js
@@ -485,12 +485,11 @@ define([
                     elem.addEventListener ? elem.addEventListener( type, fn, false ) : elem.attachEvent( "on" + type, fn );
                 };
 
-                var eventname=(/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+                var eventname='wheel';
                 addEvent(me.documentHolder.el, eventname, _.bind(me.handleDocumentWheel, me));
             }
 
-            !Common.Utils.isChrome ? $(document).on('mousewheel', _.bind(me.handleDocumentWheel, me)) :
-                document.addEventListener('mousewheel', _.bind(me.handleDocumentWheel, me), {passive: false});
+            document.addEventListener('wheel', _.bind(me.handleDocumentWheel, me), {passive: false});
             $(document).on('keydown', _.bind(me.handleDocumentKeyDown, me));
 
             $(window).on('resize', _.bind(me.onDocumentHolderResize, me));

--- a/apps/documenteditor/main/app/controller/Print.js
+++ b/apps/documenteditor/main/app/controller/Print.js
@@ -131,8 +131,7 @@ define([
             }, this));
             Common.NotificationCenter.on('margins:update', _.bind(this.onUpdateLastCustomMargins, this));
 
-            var eventname = 'wheel';
-            this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
+            this.printSettings.$previewBox[0].addEventListener('wheel', _.bind(this.onPreviewWheel, this), {passive: false});
         },
 
         setMode: function (mode) {

--- a/apps/documenteditor/main/app/controller/Print.js
+++ b/apps/documenteditor/main/app/controller/Print.js
@@ -526,7 +526,7 @@ define([
                 e.preventDefault();
                 e.stopImmediatePropagation();
             }
-            var forward = (e.deltaY || (e.detail && -e.detail) || e.wheelDelta) < 0;
+            var forward = e.deltaY > 0;
             this.onChangePreviewPage(forward);
         },
 

--- a/apps/documenteditor/main/app/controller/Print.js
+++ b/apps/documenteditor/main/app/controller/Print.js
@@ -131,7 +131,7 @@ define([
             }, this));
             Common.NotificationCenter.on('margins:update', _.bind(this.onUpdateLastCustomMargins, this));
 
-            var eventname = (/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+            var eventname = 'wheel';
             this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
         },
 

--- a/apps/pdfeditor/main/app/controller/DocumentHolder.js
+++ b/apps/pdfeditor/main/app/controller/DocumentHolder.js
@@ -338,10 +338,7 @@ define([
                 me._isScrolling = false;
             }, 100);
 
-            var delta = (_.isUndefined(event.originalEvent)) ? event.wheelDelta : event.originalEvent.wheelDelta;
-            if (_.isUndefined(delta)) {
-                delta = event.deltaY;
-            }
+            var delta = event.deltaY !== undefined ? -event.deltaY : event.wheelDelta;
 
             if (me._ctrlPressedAtScrollStart && !event.altKey) {
                 if (delta < 0) {

--- a/apps/pdfeditor/main/app/controller/DocumentHolder.js
+++ b/apps/pdfeditor/main/app/controller/DocumentHolder.js
@@ -433,12 +433,11 @@ define([
                     elem.addEventListener ? elem.addEventListener( type, fn, false ) : elem.attachEvent( "on" + type, fn );
                 };
 
-                var eventname=(/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+                var eventname='wheel';
                 addEvent(me.documentHolder.el, eventname, _.bind(me.handleDocumentWheel, me));
             }
 
-            !Common.Utils.isChrome ? $(document).on('mousewheel', _.bind(me.handleDocumentWheel, me)) :
-                document.addEventListener('mousewheel', _.bind(me.handleDocumentWheel, me), {passive: false});
+            document.addEventListener('wheel', _.bind(me.handleDocumentWheel, me), {passive: false});
             $(document).on('keydown', _.bind(me.handleDocumentKeyDown, me));
 
             $(window).on('resize', _.bind(me.onDocumentHolderResize, me));

--- a/apps/pdfeditor/main/app/controller/Print.js
+++ b/apps/pdfeditor/main/app/controller/Print.js
@@ -523,7 +523,7 @@ define([
                 e.preventDefault();
                 e.stopImmediatePropagation();
             }
-            var forward = (e.deltaY || (e.detail && -e.detail) || e.wheelDelta) < 0;
+            var forward = e.deltaY > 0;
             this.onChangePreviewPage(forward);
         },
 

--- a/apps/pdfeditor/main/app/controller/Print.js
+++ b/apps/pdfeditor/main/app/controller/Print.js
@@ -137,7 +137,7 @@ define([
             }, this));
             Common.NotificationCenter.on('margins:update', _.bind(this.onUpdateLastCustomMargins, this));
 
-            var eventname = (/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+            var eventname = 'wheel';
             this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
         },
 

--- a/apps/pdfeditor/main/app/controller/Print.js
+++ b/apps/pdfeditor/main/app/controller/Print.js
@@ -137,8 +137,7 @@ define([
             }, this));
             Common.NotificationCenter.on('margins:update', _.bind(this.onUpdateLastCustomMargins, this));
 
-            var eventname = 'wheel';
-            this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
+            this.printSettings.$previewBox[0].addEventListener('wheel', _.bind(this.onPreviewWheel, this), {passive: false});
         },
 
         setMode: function (mode) {

--- a/apps/presentationeditor/main/app/controller/DocumentHolder.js
+++ b/apps/presentationeditor/main/app/controller/DocumentHolder.js
@@ -470,10 +470,7 @@ define([
                 me._isScrolling = false;
             }, 100);
 
-            var delta = (_.isUndefined(event.originalEvent)) ? event.wheelDelta : event.originalEvent.wheelDelta;
-            if (_.isUndefined(delta)) {
-                delta = event.deltaY;
-            }
+            var delta = event.deltaY !== undefined ? -event.deltaY : event.wheelDelta;
 
             if (me._ctrlPressedAtScrollStart && !event.altKey) {
                 if (delta < 0) {

--- a/apps/presentationeditor/main/app/controller/DocumentHolder.js
+++ b/apps/presentationeditor/main/app/controller/DocumentHolder.js
@@ -273,12 +273,11 @@ define([
                     elem.addEventListener ? elem.addEventListener( type, fn, false ) : elem.attachEvent( "on" + type, fn );
                 };
 
-                var eventname=(/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+                var eventname='wheel';
                 addEvent(me.documentHolder.el, eventname, _.bind(me.handleDocumentWheel, me));
             }
 
-            !Common.Utils.isChrome ? $(document).on('mousewheel', _.bind(me.handleDocumentWheel, me)) :
-                document.addEventListener('mousewheel', _.bind(me.handleDocumentWheel, me), {passive: false});
+            document.addEventListener('wheel', _.bind(me.handleDocumentWheel, me), {passive: false});
             $(document).on('keydown', _.bind(me.handleDocumentKeyDown, me));
             $(window).on('resize', _.bind(me.onDocumentHolderResize, me));
             var viewport = me.getApplication().getController('Viewport').getView('Viewport');

--- a/apps/presentationeditor/main/app/controller/Print.js
+++ b/apps/presentationeditor/main/app/controller/Print.js
@@ -130,8 +130,7 @@ define([
                 }
             }, this));
 
-            var eventname = 'wheel';
-            this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
+            this.printSettings.$previewBox[0].addEventListener('wheel', _.bind(this.onPreviewWheel, this), {passive: false});
         },
 
         setMode: function (mode) {

--- a/apps/presentationeditor/main/app/controller/Print.js
+++ b/apps/presentationeditor/main/app/controller/Print.js
@@ -274,7 +274,7 @@ define([
                 e.preventDefault();
                 e.stopImmediatePropagation();
             }
-            var forward = (e.deltaY || (e.detail && -e.detail) || e.wheelDelta) < 0;
+            var forward = e.deltaY > 0;
             this.onChangePreviewPage(forward);
         },
 

--- a/apps/presentationeditor/main/app/controller/Print.js
+++ b/apps/presentationeditor/main/app/controller/Print.js
@@ -130,7 +130,7 @@ define([
                 }
             }, this));
 
-            var eventname = (/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+            var eventname = 'wheel';
             this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
         },
 

--- a/apps/spreadsheeteditor/main/app/controller/DocumentHolder.js
+++ b/apps/spreadsheeteditor/main/app/controller/DocumentHolder.js
@@ -348,10 +348,7 @@ define([
 
         onDocumentWheel: function(e) {
             if (this.api && !this.isEditCell) {
-                var delta = (_.isUndefined(e.originalEvent)) ?  e.wheelDelta : e.originalEvent.wheelDelta;
-                if (_.isUndefined(delta)) {
-                    delta = e.deltaY;
-                }
+                var delta = e.deltaY !== undefined ? -e.deltaY : e.wheelDelta;
 
                 if (e.ctrlKey && !e.altKey) {
                     var factor = this.api.asc_getZoom();

--- a/apps/spreadsheeteditor/main/app/controller/DocumentHolderExt.js
+++ b/apps/spreadsheeteditor/main/app/controller/DocumentHolderExt.js
@@ -253,13 +253,12 @@ define([], function () {
                 });
 
                 //NOTE: set mouse wheel handler
-                var eventname=(/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+                var eventname='wheel';
                 addEvent(view.el, eventname, _.bind(this.onDocumentWheel,this), false);
 
                 me.cellEditor = $('#ce-cell-content');
             }
-            Common.Utils.isChrome ? addEvent(document, 'mousewheel', _.bind(this.onDocumentWheel,this), { passive: false } ) :
-                $(document).on('mousewheel',    _.bind(this.onDocumentWheel, this));
+            document.addEventListener('wheel', _.bind(this.onDocumentWheel,this), { passive: false });
             this.onChangeProtectSheet();
         };
 

--- a/apps/spreadsheeteditor/main/app/controller/Print.js
+++ b/apps/spreadsheeteditor/main/app/controller/Print.js
@@ -134,8 +134,7 @@ define([
             }, this));
             Common.NotificationCenter.on('margins:update', _.bind(this.onUpdateLastCustomMargins, this));
 
-            var eventname = 'wheel';
-            this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
+            this.printSettings.$previewBox[0].addEventListener('wheel', _.bind(this.onPreviewWheel, this), {passive: false});
         },
 
         setMode: function (mode) {

--- a/apps/spreadsheeteditor/main/app/controller/Print.js
+++ b/apps/spreadsheeteditor/main/app/controller/Print.js
@@ -134,7 +134,7 @@ define([
             }, this));
             Common.NotificationCenter.on('margins:update', _.bind(this.onUpdateLastCustomMargins, this));
 
-            var eventname = (/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+            var eventname = 'wheel';
             this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
         },
 

--- a/apps/spreadsheeteditor/main/app/controller/Print.js
+++ b/apps/spreadsheeteditor/main/app/controller/Print.js
@@ -915,7 +915,7 @@ define([
             }
             this.printSettings.txtRangeTop.cmpEl.find('input:focus').blur();
             this.printSettings.txtRangeLeft.cmpEl.find('input:focus').blur();
-            var forward = (e.deltaY || (e.detail && -e.detail) || e.wheelDelta) < 0;
+            var forward = e.deltaY > 0;
             this.onChangePreviewPage(forward);
         },
 

--- a/apps/visioeditor/main/app/controller/DocumentHolder.js
+++ b/apps/visioeditor/main/app/controller/DocumentHolder.js
@@ -369,12 +369,11 @@ define([
                     elem.addEventListener ? elem.addEventListener( type, fn, false ) : elem.attachEvent( "on" + type, fn );
                 };
 
-                var eventname=(/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+                var eventname='wheel';
                 addEvent(me.documentHolder.el, eventname, _.bind(me.handleDocumentWheel, me));
             }
 
-            !Common.Utils.isChrome ? $(document).on('mousewheel', _.bind(me.handleDocumentWheel, me)) :
-                document.addEventListener('mousewheel', _.bind(me.handleDocumentWheel, me), {passive: false});
+            document.addEventListener('wheel', _.bind(me.handleDocumentWheel, me), {passive: false});
             $(document).on('keydown', _.bind(me.handleDocumentKeyDown, me));
 
             $(window).on('resize', _.bind(me.onDocumentHolderResize, me));

--- a/apps/visioeditor/main/app/controller/DocumentHolder.js
+++ b/apps/visioeditor/main/app/controller/DocumentHolder.js
@@ -273,10 +273,7 @@ define([
                 me._isScrolling = false;
             }, 100);
 
-            var delta = (_.isUndefined(event.originalEvent)) ? event.wheelDelta : event.originalEvent.wheelDelta;
-            if (_.isUndefined(delta)) {
-                delta = event.deltaY;
-            }
+            var delta = event.deltaY !== undefined ? -event.deltaY : event.wheelDelta;
 
             if (me._ctrlPressedAtScrollStart && !event.altKey) {
                 if (delta < 0) {

--- a/apps/visioeditor/main/app/controller/Print.js
+++ b/apps/visioeditor/main/app/controller/Print.js
@@ -130,8 +130,7 @@ define([
                 }
             }, this));
 
-            var eventname = 'wheel';
-            this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
+            this.printSettings.$previewBox[0].addEventListener('wheel', _.bind(this.onPreviewWheel, this), {passive: false});
         },
 
         setMode: function (mode) {

--- a/apps/visioeditor/main/app/controller/Print.js
+++ b/apps/visioeditor/main/app/controller/Print.js
@@ -274,7 +274,7 @@ define([
                 e.preventDefault();
                 e.stopImmediatePropagation();
             }
-            var forward = (e.deltaY || (e.detail && -e.detail) || e.wheelDelta) < 0;
+            var forward = e.deltaY > 0;
             this.onChangePreviewPage(forward);
         },
 

--- a/apps/visioeditor/main/app/controller/Print.js
+++ b/apps/visioeditor/main/app/controller/Print.js
@@ -130,7 +130,7 @@ define([
                 }
             }, this));
 
-            var eventname = (/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'mousewheel';
+            var eventname = 'wheel';
             this.printSettings.$previewBox.on(eventname, _.bind(this.onPreviewWheel, this));
         },
 

--- a/build/common.json
+++ b/build/common.json
@@ -214,28 +214,6 @@
             }
         }
     },
-    "fetch": {
-        "clean": [
-            "$BUILD_ROOT/web-apps/vendor/fetch"
-        ],
-        "copy": {
-            "script": {
-                "src": "../vendor/fetch/fetch.umd.js",
-                "dest": "$BUILD_ROOT/web-apps/vendor/fetch/fetch.umd.js"
-            }
-        }
-    },
-    "es6-promise": {
-        "clean": [
-            "$BUILD_ROOT/web-apps/vendor/es6-promise"
-        ],
-        "copy": {
-            "script": {
-                "src": "../vendor/es6-promise/es6-promise.auto.min.js",
-                "dest": "$BUILD_ROOT/web-apps/vendor/es6-promise/es6-promise.auto.min.js"
-            }
-        }
-    },
     "requirejs": {
         "clean": [
             "$BUILD_ROOT/web-apps/vendor/requirejs"
@@ -282,8 +260,6 @@
             "deploy-jquery",
             "deploy-underscore",
             "deploy-iscroll",
-            "deploy-fetch",
-            "deploy-es6-promise",
             "deploy-common-embed",
             "deploy-monaco"
         ]

--- a/build/vendor.manifest.mjs
+++ b/build/vendor.manifest.mjs
@@ -38,8 +38,6 @@ export const VENDORS = [
     { name: 'socketio',      src: 'socketio/socket.io.min.js',              dest: 'vendor/socketio/socket.io.min.js' },
     { name: 'xregexp',       src: 'xregexp/xregexp-all-min.js',             dest: 'vendor/xregexp/xregexp-all-min.js' },
     { name: 'underscore',    src: 'underscore/underscore-min.js',           dest: 'vendor/underscore/underscore-min.js' },
-    { name: 'fetch',         src: 'fetch/fetch.umd.js',                     dest: 'vendor/fetch/fetch.umd.js' },
-    { name: 'es6-promise',   src: 'es6-promise/es6-promise.auto.min.js',    dest: 'vendor/es6-promise/es6-promise.auto.min.js' },
 
     // ---- requirejs (minified before copy — deploy-common handles specially) ---
     { name: 'requirejs',     src: 'requirejs/require.js',                   dest: 'vendor/requirejs/require.js', minify: true },


### PR DESCRIPTION
Low-hanging-fruit browser-floor cleanup — removes dead weight, no behavioural risk on the modern floor.

- 🔥 Stop deploying `fetch` / `es6-promise` polyfills (unused once IE/legacy is off the floor).
- 🐛 Replace `DOMMouseScroll` / `mousewheel` UA-sniffing with the standard `wheel` event across desktop editors.

<details>
<summary>Details</summary>

**Polyfills** — `fetch` and `es6-promise` are dropped from `build/vendor.manifest.mjs`, so the deploy step stops copying them. The vendor dirs stay in the tree (upstream keeps shipping them); we just don't deploy them.

**Wheel/scroll** — three fixes in the desktop editors' `Print.js` / `DocumentHolder.js`:
1. Replace the `DOMMouseScroll`/`mousewheel` UA-sniff with the standard `wheel` event.
2. Switch `Print.js` binding from jQuery `.on()` to `addEventListener`.
3. Correct the wheel `delta` sign in `Print.js` and `DocumentHolder.js`.

Part of the browser-floor-stage1 work; the mobile/ES2022 half is a separate PR.
</details>
