### PR TITLE
fix(mobile): show copy/cut/paste icons in context actions

### DIFF
--- a/apps/common/mobile/lib/editor.jsx
+++ b/apps/common/mobile/lib/editor.jsx
@@ -9,12 +9,18 @@ import IconUndoIos from '@common-ios-icons/icon-undo.svg?ios';
 import IconUndoAndroid from '@common-android-icons/icon-undo.svg';
 import IconRedoIos from '@common-ios-icons/icon-redo.svg?ios';
 import IconRedoAndroid from '@common-android-icons/icon-redo.svg';
+import IconCopy from '@common-icons/icon-copy.svg';
+import IconCut from '@common-icons/icon-cut.svg';
+import IconPaste from '@common-icons/icon-paste.svg';
 
 export const icons = {
     edit: { ios: IconEditSettingsIos, android: IconEditSettingsAndroid },
     add: { ios: IconAddOtherIos, android: IconAddOtherAndroid },
     undo: { ios: IconUndoIos, android: IconUndoAndroid },
     redo: { ios: IconRedoIos, android: IconRedoAndroid },
+    copy: IconCopy,
+    cut: IconCut,
+    paste: IconPaste,
 };
 
 /**

--- a/apps/documenteditor/mobile/src/controller/ContextMenu.jsx
+++ b/apps/documenteditor/mobile/src/controller/ContextMenu.jsx
@@ -6,6 +6,7 @@ import { LocalStorage } from '../../../../common/mobile/utils/LocalStorage.mjs';
 import ContextMenuController from '../../../../common/mobile/lib/controller/ContextMenu';
 import { idContextMenuElement } from '../../../../common/mobile/lib/view/ContextMenu';
 import EditorUIController from '../lib/patch';
+import { icons } from '../../../../common/mobile/lib/editor';
 
 @inject(stores => ({
     isEdit: stores.storeAppOptions.isEdit,
@@ -324,7 +325,7 @@ class ContextMenu extends ContextMenuController {
             if (canCopy) {
                 itemsIcon.push({
                     event: 'copy',
-                    icon: 'icon-copy'
+                    icon: icons.copy.id
                 });
             }
 
@@ -332,14 +333,14 @@ class ContextMenu extends ContextMenuController {
                 if (canFillForms && canCopy && !locked && (!isViewer || isForm) && isAllowedEditing) {
                     itemsIcon.push({
                         event: 'cut',
-                        icon: 'icon-cut'
+                        icon: icons.cut.id
                     });
                 }
 
                 if (canFillForms && canCopy && !locked && (!isViewer || isForm) && isAllowedEditing) {
                     itemsIcon.push({
                         event: 'paste',
-                        icon: 'icon-paste'
+                        icon: icons.paste.id
                     });
                 }
 

--- a/apps/documenteditor/mobile/src/lib/editor.jsx
+++ b/apps/documenteditor/mobile/src/lib/editor.jsx
@@ -229,15 +229,15 @@ export const ContextMenu = {
             itemsText = [];
 
         if (canCopy) {
-            itemsIcon.push({ event: 'copy', icon: 'icon-copy' });
+            itemsIcon.push({ event: 'copy', icon: icons.copy.id });
         }
 
         if (!isDisconnected) {
             if (canCopy && !locked && isAllowedEditing) {
-                itemsIcon.push({ event: 'cut', icon: 'icon-cut' });
+                itemsIcon.push({ event: 'cut', icon: icons.cut.id });
             }
             if (!locked && isAllowedEditing) {
-                itemsIcon.push({ event: 'paste', icon: 'icon-paste' });
+                itemsIcon.push({ event: 'paste', icon: icons.paste.id });
             }
             if (canViewComments && controller.isComments) {
                 itemsText.push({ caption: _t.menuViewComment, event: 'viewcomment' });

--- a/apps/presentationeditor/mobile/src/controller/ContextMenu.jsx
+++ b/apps/presentationeditor/mobile/src/controller/ContextMenu.jsx
@@ -8,6 +8,7 @@ import ContextMenuController from '../../../../common/mobile/lib/controller/Cont
 import { idContextMenuElement } from '../../../../common/mobile/lib/view/ContextMenu';
 // import { Device } from '../../../../common/mobile/utils/device';
 import EditorUIController from '../lib/patch';
+import { icons } from '../../../../common/mobile/lib/editor';
 
 @inject(stores => ({
     isEdit: stores.storeAppOptions.isEdit,
@@ -294,7 +295,7 @@ class ContextMenu extends ContextMenuController {
             if (canCopy && isObject) {
                 itemsIcon.push({
                     event: 'copy',
-                    icon: 'icon-copy'
+                    icon: icons.copy.id
                 });
             }
             if(!isDisconnected && !isVersionHistoryMode) {

--- a/apps/presentationeditor/mobile/src/lib/editor.jsx
+++ b/apps/presentationeditor/mobile/src/lib/editor.jsx
@@ -288,7 +288,7 @@ export const ContextMenu = {
         const isObject = isText || isImage || isChart || isShape || isTable;
 
         if (canCopy && isObject) {
-            itemsIcon.push({ event: 'copy', icon: 'icon-copy' });
+            itemsIcon.push({ event: 'copy', icon: icons.copy.id });
         }
 
         if (stack.length > 0) {
@@ -301,7 +301,7 @@ export const ContextMenu = {
 
             if (!locked && !isDisconnected && !isVersionHistoryMode) {
                 if (canCopy && isObject) {
-                    itemsIcon.push({ event: 'cut', icon: 'icon-cut' });
+                    itemsIcon.push({ event: 'cut', icon: icons.cut.id });
                     // Move cut before copy
                     if (itemsIcon.length === 2) {
                         let tmp = itemsIcon[0];
@@ -309,7 +309,7 @@ export const ContextMenu = {
                         itemsIcon[1] = tmp;
                     }
                 }
-                itemsIcon.push({ event: 'paste', icon: 'icon-paste' });
+                itemsIcon.push({ event: 'paste', icon: icons.paste.id });
 
                 if (isTable && api.CheckBeforeMergeCells()) {
                     itemsText.push({ caption: _t.menuMerge, event: 'merge' });

--- a/apps/spreadsheeteditor/mobile/src/controller/ContextMenu.jsx
+++ b/apps/spreadsheeteditor/mobile/src/controller/ContextMenu.jsx
@@ -6,6 +6,7 @@ import { LocalStorage } from '../../../../common/mobile/utils/LocalStorage.mjs';
 import ContextMenuController from '../../../../common/mobile/lib/controller/ContextMenu';
 import { idContextMenuElement } from '../../../../common/mobile/lib/view/ContextMenu';
 import EditorUIController from '../lib/patch';
+import { icons } from '../../../../common/mobile/lib/editor';
 
 @inject(stores => ({
     isEdit: stores.storeAppOptions.isEdit,
@@ -283,7 +284,7 @@ class ContextMenu extends ContextMenuController {
 
                 itemsIcon.push({
                     event: 'copy',
-                    icon: 'icon-copy'
+                    icon: icons.copy.id
                 });
     
                 if (iscellmenu && cellinfo.asc_getHyperlink()) {

--- a/apps/spreadsheeteditor/mobile/src/lib/editor.jsx
+++ b/apps/spreadsheeteditor/mobile/src/lib/editor.jsx
@@ -285,11 +285,11 @@ export const ContextMenu = {
         }
 
         if (locked || api.isCellEdited || isDisconnected) {
-            itemsIcon.push({ event: 'copy', icon: 'icon-copy' });
+            itemsIcon.push({ event: 'copy', icon: icons.copy.id });
         } else if (!isVersionHistoryMode) {
-            itemsIcon.push({ event: 'cut', icon: 'icon-cut' });
-            itemsIcon.push({ event: 'copy', icon: 'icon-copy' });
-            itemsIcon.push({ event: 'paste', icon: 'icon-paste' });
+            itemsIcon.push({ event: 'cut', icon: icons.cut.id });
+            itemsIcon.push({ event: 'copy', icon: icons.copy.id });
+            itemsIcon.push({ event: 'paste', icon: icons.paste.id });
 
             if (isImage || isShape || isChart || isShapeText || isChartText) {
                 itemsText.push({ caption: _t.menuEdit, event: 'edit' });


### PR DESCRIPTION
On the mobile editor, you can have access to contextual actions based on the selected element. For items that should be shown as icons, those icons aren't imported in the JSX code. That cause the icons to be missing in all editors. 

<details><summary>Show screenshot of the missing icon in spreadsheeteditor</summary>
<img width="463" height="981" alt="image" src="https://github.com/user-attachments/assets/cd19f77d-e727-412b-a2a0-7ecb3191db5d" />
</details> 

This PR fixes it. For now it is only testable in the fallback path since ContextAction is commented out, but it's simple enough to be merged as is. 

Not providing a picture of it working due to https://github.com/Euro-Office/DocumentServer/issues/258 but I have tested it. 
