### PR TITLE
Remove SKIP_MOBILE — always build & gate mobile in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            web-apps/build/package-lock.json
+            web-apps/vendor/framework7-react/npm-shrinkwrap.json
 
       # Mirrors web-apps.bake.Dockerfile so the overlay matches the shipped build.
       - name: Install build prerequisites

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,7 +88,6 @@ jobs:
           BUILD_ROOT: ${{ github.workspace }}/web-apps/deploy
           THEME: euro-office
           PRODUCT_VERSION: ${{ steps.ver.outputs.product_version }}
-          SKIP_MOBILE: '1'
         run: |
           npm install
           ( cd ../translation && python3 merge_and_check.py )

--- a/Readme.md
+++ b/Readme.md
@@ -101,12 +101,6 @@ docker compose exec eo bash
 export BUILD_NUMBER=0 PRODUCT_VERSION=9.3.2 THEME=euro-office && cd /var/www/onlyoffice/web-apps-develop/build && node scripts/build-pipeline.js
 ```
 
-### Build Flags
-
-| Flag | Description |
-|------|-------------|
-| `SKIP_MOBILE=1` | Skip framework7-react mobile builds (~50s saved) |
-
 ### Environment Variables
 
 | Variable | Description |

--- a/build/README.md
+++ b/build/README.md
@@ -17,10 +17,6 @@ the webpack 5 build system.
 cd /develop/web-apps/build
 PRODUCT_VERSION=9.2.1 BUILD_ROOT=/var/www/onlyoffice/documentserver THEME=euro-office \
   node scripts/build-pipeline.js
-
-# Skip mobile builds (saves ~50s — safe when you haven't touched framework7-react):
-SKIP_MOBILE=1 PRODUCT_VERSION=9.2.1 BUILD_ROOT=... THEME=euro-office \
-  node scripts/build-pipeline.js
 ```
 
 `make web-apps-dev` in the `eo` container calls the same pipeline via the
@@ -45,7 +41,7 @@ Phase 1 — all in parallel
   webpack ×6                  bundle app.js / code.js / app.css / locale per editor (desktop, Terser)
   mobile ×4                   framework7-react webpack builds into the SOURCE tree (word, cell, slide, visio; esbuild)
 
-Phase 2 — mobile deploy (skipped when SKIP_MOBILE=1)
+Phase 2 — mobile deploy
   deploy-mobile.js            copy mobile output (index.html → index.html + index_loader.html, dist/,
                               css/, locale/, resources/img/) from source tree → BUILD_ROOT for the 4
                               mobile editors. MUST precede deploy-theme-images' mobile img overlay.
@@ -59,7 +55,7 @@ Phase 4 — inline
 
 Phase 5 — gates (fail the build loudly)
   verify-bundles.mjs          scan built bundles for surviving {{TOKEN}} literals
-  verify-deploy.mjs           assert every required artifact exists (incl. mobile when !SKIP_MOBILE)
+  verify-deploy.mjs           assert every required artifact exists (incl. mobile)
   verify-browser-target.mjs   no hardcoded browser targets; configs import build/browser-floor.mjs
 ```
 
@@ -73,7 +69,6 @@ Phase 5 — gates (fail the build loudly)
 | `BUILD_ROOT` | **yes** | `../deploy` | Absolute path to DocumentServer output root. |
 | `BUILD_NUMBER` | no | `GITHUB_RUN_NUMBER` → `common.json.build` | Appended to version string in JS bundles. Auto-increments in CI via `GITHUB_RUN_NUMBER`. |
 | `THEME` | no | `default` | Theme directory name under `theme/`. EuroOffice uses `euro-office`. |
-| `SKIP_MOBILE` | no | `0` | Set to `1` to skip framework7-react builds + the Phase 2 mobile deploy (~50s). Safe when not touching mobile code. |
 | `NODE_ENV` | no | `production` | Build mode, forced onto every child. `development` = unminified, `console` kept, esbuild minifier off for mobile (so the ES target + `drop_console` do NOT run — never validate a fix on a dev build). The pipeline echoes the resolved mode in its banner (green prod / red DEV warning). |
 | `WATCH` | no | `0` | `1` = mobile webpack watch mode (live rebuild). Decoupled from `NODE_ENV`; for direct `build.js` runs only — the pipeline would hang on a watching child. |
 | `APP_COPYRIGHT` | no | auto | Copyright line in JS preamble. |
@@ -156,7 +151,7 @@ Preflight + Phase 5. Fail the build loudly rather than ship a silent defect:
 - `verify-replacements.mjs` — preflight: source-side string-replace idiom audit.
 - `verify-bundles.mjs` — scans built bundles for surviving `{{TOKEN}}` literals.
 - `verify-deploy.mjs` — asserts every required artifact exists (vendor/embed/main/forms;
-  mobile `index.html`/`dist`/`css`/`locale` when `!SKIP_MOBILE`).
+  mobile `index.html`/`dist`/`css`/`locale`).
 - `verify-browser-target.mjs` — fails if any webpack/babel/postcss config hardcodes a
   browser target instead of importing from `build/browser-floor.mjs`.
 

--- a/build/scripts/build-pipeline.js
+++ b/build/scripts/build-pipeline.js
@@ -83,6 +83,9 @@ const CHILD_ENV = {
     BUILD_NUMBER,
     THEME,
     NODE_ENV,
+    // Never inherit watch mode from the parent shell — a watching mobile child
+    // (webpack.config.js: watch === WATCH==='1') never exits and hangs the pipeline.
+    WATCH: '0',
 };
 
 // ---- output helpers ---------------------------------------------------------

--- a/build/scripts/build-pipeline.js
+++ b/build/scripts/build-pipeline.js
@@ -315,7 +315,7 @@ async function main() {
 
     // ---- summary -------------------------------------------------------------
 
-    const all = [...p0, ...p1, ...pMobile, ...p2, ...p3, ...p4];
+    const all = [...p0, install, ...p1, ...pMobile, ...p2, ...p3, ...p4];
     const wallMs = Date.now() - wallStart;
 
     const longestLabel = Math.max(...all.map(r => r.label.length));

--- a/build/scripts/build-pipeline.js
+++ b/build/scripts/build-pipeline.js
@@ -26,13 +26,12 @@
 //   BUILD_ROOT       default: ../deploy (matches grunt's default)
 //   BUILD_NUMBER     default: GITHUB_RUN_NUMBER, then common.json.build
 //   THEME            default: default
-//   SKIP_MOBILE      set to 1 to skip framework7-react builds (~50s saved)
 //
 // Phase layout (wall-clock optimised):
 //   Phase 1 — all parallel:
 //     sprites.sh, deploy-common, deploy-html, deploy-reporter,
 //     deploy-embed, webpack ×6, mobile ×4
-//   Phase 2 — conditional on !SKIP_MOBILE (sequential after Phase 1):
+//   Phase 2 — sequential after Phase 1:
 //     deploy-mobile     (copies mobile output from source tree to BUILD_ROOT)
 //   Phase 3 — parallel (start as soon as Phase 2 done):
 //     deploy-resources  (deploys per-editor toolbar/icons.svg)
@@ -70,8 +69,6 @@ const BUILD_NUMBER = String(
 );
 
 const THEME = process.env.THEME || 'default';
-
-const SKIP_MOBILE = process.env.SKIP_MOBILE === '1';
 
 // Default every child to production so mobile (webpack.config.js defaults to
 // 'development') and desktop (defaults to 'production') agree — without this the
@@ -235,7 +232,6 @@ async function main() {
         `  PRODUCT_VERSION  ${PRODUCT_VERSION}`,
         `  BUILD_NUMBER     ${BUILD_NUMBER}`,
         `  THEME            ${THEME}`,
-        `  SKIP_MOBILE      ${SKIP_MOBILE}`,
         `  NODE_ENV         ${NODE_ENV === 'production'
             ? GREEN(NODE_ENV)
             : RED(`${NODE_ENV}  ⚠ DEV BUILD — minifier off; not for deploy or fix-validation`)}`,
@@ -265,28 +261,26 @@ async function main() {
 
     // Mobile: npm install first (sequential), then 4 editors in parallel.
     // Run as a pre-phase so all 4 editor tasks appear individually in the summary.
-    if (!SKIP_MOBILE) {
-        const install = await runTask(task('mobile:install', 'npm',
-            ['install', '--include=dev', '--production=false'],
-            { cwd: FRAMEWORK7_DIR }
-        )).promise;
-        if (install.code !== 0) {
-            process.stderr.write(RED(`\n✗ mobile:install failed — aborting\n`));
-            process.exit(1);
-        }
-        MOBILE_EDITORS.forEach(editor =>
-            phase1Tasks.push(task(`mobile:${editor}`, node, ['build/build.js'],
-                { cwd: FRAMEWORK7_DIR, env: { TARGET_EDITOR: editor } } // NODE_ENV now in CHILD_ENV
-            ))
-        );
+    const install = await runTask(task('mobile:install', 'npm',
+        ['install', '--include=dev', '--production=false'],
+        { cwd: FRAMEWORK7_DIR }
+    )).promise;
+    if (install.code !== 0) {
+        process.stderr.write(RED(`\n✗ mobile:install failed — aborting\n`));
+        process.exit(1);
     }
+    MOBILE_EDITORS.forEach(editor =>
+        phase1Tasks.push(task(`mobile:${editor}`, node, ['build/build.js'],
+            { cwd: FRAMEWORK7_DIR, env: { TARGET_EDITOR: editor } } // NODE_ENV now in CHILD_ENV
+        ))
+    );
 
     const p1 = await phase('Phase 1 — parallel', phase1Tasks);
 
-    // ---- phase 2: deploy-mobile (conditional) --------------------------------
+    // ---- phase 2: deploy-mobile ----------------------------------------------
     // Must run before deploy-theme-images: both write to <editor>/mobile/resources/img/
     // and theme images must win the overlay (deploy-theme-images.js:69).
-    const pMobile = SKIP_MOBILE ? [] : await phase('Phase 2 — mobile deploy', [
+    const pMobile = await phase('Phase 2 — mobile deploy', [
         task('deploy-mobile', node, ['scripts/deploy-mobile.js']),
     ]);
 

--- a/build/scripts/deploy-mobile.js
+++ b/build/scripts/deploy-mobile.js
@@ -33,7 +33,9 @@
 // must win, so deploy-mobile runs first).
 //
 // Copy-merge only — never wipes the destination. BUILD_ROOT must be set.
-// Soft-skips any editor whose mobile/index.html is absent.
+// Fails loudly if any editor's mobile/index.html is absent: in the pipeline all
+// four mobile editors always build, so a miss means a failed/killed build, not a
+// legitimate skip — better to fail here than let Phases 3-5 run on a partial deploy.
 
 const fs   = require('fs');
 const path = require('path');
@@ -96,12 +98,19 @@ function deployEditor(editor) {
     console.log(`deploy-mobile: ${editor} done`);
 }
 
+let missing = false;
 for (const editor of MOBILE_EDITORS) {
     if (!fs.existsSync(path.join(APPS_SRC, editor, 'mobile', 'index.html'))) {
-        console.log(`deploy-mobile: ${editor} — no mobile/index.html, skipping`);
+        console.error(`deploy-mobile: ${editor} — mobile/index.html missing (build failed or was killed)`);
+        missing = true;
         continue;
     }
     deployEditor(editor);
+}
+
+if (missing) {
+    console.error('deploy-mobile: FAILED — expected mobile output missing; not deploying a partial build');
+    process.exit(1);
 }
 
 console.log('deploy-mobile: all editors done');

--- a/build/scripts/verify-deploy.mjs
+++ b/build/scripts/verify-deploy.mjs
@@ -43,8 +43,6 @@ const BUILD_ROOT = process.env.BUILD_ROOT
     ? path.resolve(process.env.BUILD_ROOT)
     : path.resolve(__dirname, '../../deploy');
 
-const SKIP_MOBILE = process.env.SKIP_MOBILE === '1';
-
 const BUILD_OUT = path.join(BUILD_ROOT, 'web-apps');
 
 const EDITORS        = ['documenteditor', 'spreadsheeteditor', 'presentationeditor', 'visioeditor', 'pdfeditor'];
@@ -104,25 +102,23 @@ for (const ed of EDITORS) {
 checkFile('apps/documenteditor/forms/app.js');
 checkFile('apps/documenteditor/forms/code.js');
 
-// ---- mobile (skipped when SKIP_MOBILE=1) ------------------------------------
-if (!SKIP_MOBILE) {
-    for (const ed of MOBILE_EDITORS) {
-        const base = `apps/${ed}/mobile`;
-        checkFile(`${base}/index.html`);
-        checkFile(`${base}/index_loader.html`);
-        checkFile(`${base}/dist/js/app.js`);   // stable unhashed JS entry — checkDir alone would pass on a chunk/.map-only dist
-        checkDir(`${base}/dist`);
-        checkDir(`${base}/css`);
-        checkDir(`${base}/locale`);
-        // Defense-in-depth: assert the hashed CSS href in index.html actually exists.
-        // CSS is contenthash-named (parse the href); the JS entry is the stable
-        // dist/js/app.js asserted above.
-        const indexAbs = path.join(BUILD_OUT, base, 'index.html');
-        if (fs.existsSync(indexAbs)) {
-            const html = fs.readFileSync(indexAbs, 'utf8');
-            for (const [, ref] of html.matchAll(/href="(css\/[^"]+\.css)"/g)) {
-                checkFile(`${base}/${ref}`);
-            }
+// ---- mobile -------------------------------------------------------------
+for (const ed of MOBILE_EDITORS) {
+    const base = `apps/${ed}/mobile`;
+    checkFile(`${base}/index.html`);
+    checkFile(`${base}/index_loader.html`);
+    checkFile(`${base}/dist/js/app.js`);   // stable unhashed JS entry — checkDir alone would pass on a chunk/.map-only dist
+    checkDir(`${base}/dist`);
+    checkDir(`${base}/css`);
+    checkDir(`${base}/locale`);
+    // Defense-in-depth: assert the hashed CSS href in index.html actually exists.
+    // CSS is contenthash-named (parse the href); the JS entry is the stable
+    // dist/js/app.js asserted above.
+    const indexAbs = path.join(BUILD_OUT, base, 'index.html');
+    if (fs.existsSync(indexAbs)) {
+        const html = fs.readFileSync(indexAbs, 'utf8');
+        for (const [, ref] of html.matchAll(/href="(css\/[^"]+\.css)"/g)) {
+            checkFile(`${base}/${ref}`);
         }
     }
 }

--- a/build/scripts/verify-deploy.mjs
+++ b/build/scripts/verify-deploy.mjs
@@ -110,6 +110,11 @@ for (const ed of MOBILE_EDITORS) {
     checkFile(`${base}/dist/js/app.js`);   // stable unhashed JS entry — checkDir alone would pass on a chunk/.map-only dist
     checkDir(`${base}/dist`);
     checkDir(`${base}/css`);
+    // framework7 stylesheets are CopyWebpackPlugin static copies loaded via a JS
+    // load_stylesheet() call, not a <link href> — invisible to the href scan below,
+    // and checkDir passes on any CSS file. Assert them explicitly.
+    checkFile(`${base}/css/framework7.css`);
+    checkFile(`${base}/css/framework7-rtl.css`);
     checkDir(`${base}/locale`);
     // Defense-in-depth: assert the hashed CSS href in index.html actually exists.
     // CSS is contenthash-named (parse the href); the JS entry is the stable

--- a/docs/webpack-migration.md
+++ b/docs/webpack-migration.md
@@ -11,7 +11,7 @@ Branch: `build/webpack-migration`. Merged: 2026-06-15.
 
 **After**: Six webpack configs (one per editor) handle JS/CSS bundling. Six Node.js scripts handle everything else. A parallel orchestrator (`build/scripts/build-pipeline.js`) replaces the sequential Makefile chain.
 
-**CI time**: ~7 minutes → ~2 minutes (cold runner) — speedup comes from webpack's faster bundling vs r.js, plus `build-pipeline.js` running all Phase 1 tasks in parallel. **Local (eo container, SKIP_MOBILE=1, cold cache)**: ~101s.
+**CI time**: ~7 minutes → ~2 minutes (cold runner) — speedup comes from webpack's faster bundling vs r.js, plus `build-pipeline.js` running all Phase 1 tasks in parallel.
 
 **Editors covered**: documenteditor, spreadsheeteditor, presentationeditor, visioeditor, pdfeditor, forms.
 
@@ -26,7 +26,6 @@ PRODUCT_VERSION=9.2.1 BUILD_ROOT=/var/www/onlyoffice/documentserver THEME=euro-o
 # Or via Makefile — invoke inside the eo container from the host:
 docker exec eo make web-apps
 docker exec eo make web-apps-dev              # incremental (node_modules must exist)
-docker exec eo make web-apps-dev SKIP_MOBILE=1
 ```
 
 `PRODUCT_VERSION` is required and must match the SDK version (see gotcha #1 below).


### PR DESCRIPTION
Closes #157.

Removes the `SKIP_MOBILE` escape hatch so CI can no longer skip building and gating mobile — the blind spot that let Euro-Office/DocumentServer#258 ship a broken mobile editor with green CI. Mobile now always builds and `verify-deploy.mjs` always asserts its artifacts.

## Changes (web-apps)

- **`.github/workflows/e2e.yml`** — drop `SKIP_MOBILE: '1'` from the build step. This is the change that matters: it arms the mobile gate #156 added.
- **`build/scripts/build-pipeline.js`** — mobile install + the 4 editor builds + Phase 2 `deploy-mobile` are now unconditional.
- **`build/scripts/verify-deploy.mjs`** — drop the `if (!SKIP_MOBILE)` wrapper; mobile artifacts always asserted.
- **`Readme.md` / `build/README.md` / `docs/webpack-migration.md`** — remove all `SKIP_MOBILE` documentation.

No deprecation shim: the flag was one day old with only two internal call sites (this workflow + the DocumentServer Makefile), so there's no installed base to warn.

## Relationship to #154

#154 Tier 1 (mobile manifest gate) already landed in #156, just gated behind `SKIP_MOBILE`. This PR makes it unconditional and completes #154's **entire web-apps footprint**. #154 Tier 2 (real-browser mobile smoke) lives in `documentserver/e2e` — a separate DocumentServer PR.

## Follow-up (not here — DocumentServer repo)

- `develop/setup/Makefile` still forwards `SKIP_MOBILE`. It's now a silent no-op (harmless — mobile builds regardless), but dead cruft to remove.
- #154 Tier 2 mobile Playwright smoke test.

## Verification

- `git grep SKIP_MOBILE` across web-apps → nothing.
- `node --check` passes on both edited scripts.
- ⚠️ **This is the first time CI will ever build mobile** (every prior e2e run had `SKIP_MOBILE=1`). Watch the build step — if framework7-react has a CI-specific install/build quirk, it surfaces here for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
