### PR TITLE
Add icon to mobile close action

### DIFF
--- a/apps/common/mobile/resources/less/common.less
+++ b/apps/common/mobile/resources/less/common.less
@@ -1249,15 +1249,10 @@ input[type="number"]::-webkit-inner-spin-button {
 
 // Close editor button
 .close-editor-btn {
-    .item-inner {
-        padding-left: 36px;
-    }
-
     .item-title {
         color: @text-error;
     }
 }
-
 
 
 

--- a/apps/documenteditor/mobile/src/view/settings/SettingsPage.jsx
+++ b/apps/documenteditor/mobile/src/view/settings/SettingsPage.jsx
@@ -26,6 +26,7 @@ import IconHelp from '@common-icons/icon-help.svg';
 import IconAbout from '@common-icons/icon-about.svg';
 import IconFeedbackForIos from '@common-ios-icons/icon-feedback.svg?ios';
 import IconFeedbackForAndroid from '@common-android-icons/icon-feedback.svg';
+import IconClose from '@common-android-icons/icon-close.svg';
 import IconReturnIos from '@common-ios-icons/icon-return.svg?ios';
 import IconReturnAndroid from '@common-android-icons/icon-return.svg';
 import IconDraw from '../../../../../common/mobile/resources/icons/draw.svg'
@@ -226,7 +227,9 @@ const SettingsPage = inject("storeAppOptions", "storeReview", "storeDocumentInfo
                     </ListItem>
                 }
                 {canCloseEditor &&
-                    <ListItem title={closeButtonText ?? t('Settings.textClose')} link="#" className='close-editor-btn no-indicator' onClick={() => Common.Notifications.trigger('close')}></ListItem>
+                    <ListItem title={closeButtonText ?? t('Settings.textClose')} link="#" className='close-editor-btn no-indicator' onClick={() => Common.Notifications.trigger('close')}>
+                        <SvgIcon slot="media" symbolId={IconClose.id} className={'icon icon-svg'} />
+                    </ListItem>
                 }
             </List>
         </Page>

--- a/apps/presentationeditor/mobile/src/view/settings/SettingsPage.jsx
+++ b/apps/presentationeditor/mobile/src/view/settings/SettingsPage.jsx
@@ -18,6 +18,7 @@ import IconHelp from '@common-icons/icon-help.svg';
 import IconAbout from '@common-icons/icon-about.svg';
 import IconFeedbackIos from '@common-ios-icons/icon-feedback.svg?ios';
 import IconFeedbackAndroid from '@common-android-icons/icon-feedback.svg';
+import IconClose from '@common-android-icons/icon-close.svg';
 import IconReturnIos from '@common-ios-icons/icon-return.svg?ios';
 import IconReturnAndroid from '@common-android-icons/icon-return.svg';
 
@@ -158,7 +159,9 @@ const SettingsPage = inject('storeAppOptions', 'storeToolbarSettings', 'storePre
                     </ListItem>
                 }
                 {canCloseEditor &&
-                    <ListItem title={closeButtonText ?? t('View.Settings.textClose')} link="#" className='close-editor-btn no-indicator' onClick={() => Common.Notifications.trigger('close')}></ListItem>
+                    <ListItem title={closeButtonText ?? t('View.Settings.textClose')} link="#" className='close-editor-btn no-indicator' onClick={() => Common.Notifications.trigger('close')}>
+                        <SvgIcon slot="media" symbolId={IconClose.id} className={'icon icon-svg'} />
+                    </ListItem>
                 }
             </List>
         </Page>

--- a/apps/spreadsheeteditor/mobile/src/view/settings/SettingsPage.jsx
+++ b/apps/spreadsheeteditor/mobile/src/view/settings/SettingsPage.jsx
@@ -17,6 +17,7 @@ import IconHelp from '@common-icons/icon-help.svg';
 import IconAbout from '@common-icons/icon-about.svg';
 import IconFeedbackIos from '@common-ios-icons/icon-feedback.svg?ios';
 import IconFeedbackAndroid from '@common-android-icons/icon-feedback.svg';
+import IconClose from '@common-android-icons/icon-close.svg';
 import IconTableSettings from '@icons/icon-table-settings.svg';
 import IconReturnIos from '@common-ios-icons/icon-return.svg?ios';
 import IconReturnAndroid from '@common-android-icons/icon-return.svg';
@@ -158,7 +159,9 @@ const SettingsPage = inject('storeAppOptions', 'storeSpreadsheetInfo', 'storeToo
                     </ListItem>
                 }
                 {canCloseEditor &&
-                    <ListItem title={closeButtonText ?? t('View.Settings.textClose')} link="#" className='close-editor-btn no-indicator' onClick={() => Common.Notifications.trigger('close')}></ListItem>
+                    <ListItem title={closeButtonText ?? t('View.Settings.textClose')} link="#" className='close-editor-btn no-indicator' onClick={() => Common.Notifications.trigger('close')}>
+                        <SvgIcon slot="media" symbolId={IconClose.id} className={'icon icon-svg'} />
+                    </ListItem>
                 }
             </List>
         </Page>

--- a/apps/visioeditor/mobile/src/view/settings/SettingsPage.jsx
+++ b/apps/visioeditor/mobile/src/view/settings/SettingsPage.jsx
@@ -14,6 +14,7 @@ import IconHelp from '@common-icons/icon-help.svg';
 import IconAbout from '@common-icons/icon-about.svg';
 import IconFeedbackIos from '@common-ios-icons/icon-feedback.svg?ios';
 import IconFeedbackAndroid from '@common-android-icons/icon-feedback.svg';
+import IconClose from '@common-android-icons/icon-close.svg';
 import IconReturnIos from '@common-ios-icons/icon-return.svg?ios';
 import IconReturnAndroid from '@common-android-icons/icon-return.svg';
 
@@ -124,7 +125,9 @@ const SettingsPage = inject('storeAppOptions', 'storeVisioInfo', 'storeToolbarSe
                     </ListItem>
                 }
                 {canCloseEditor &&
-                    <ListItem title={closeButtonText ?? t('View.Settings.textClose')} link="#" className='close-editor-btn no-indicator' onClick={() => Common.Notifications.trigger('close')}></ListItem>
+                    <ListItem title={closeButtonText ?? t('View.Settings.textClose')} link="#" className='close-editor-btn no-indicator' onClick={() => Common.Notifications.trigger('close')}>
+                        <SvgIcon slot="media" symbolId={IconClose.id} className={'icon icon-svg'} />
+                    </ListItem>
                 }
             </List>
         </Page>


### PR DESCRIPTION
## What changed

- add the shared close icon to the mobile close menu item
- apply the change to document, spreadsheet, presentation, and Visio editors
- remove the legacy 36 px title indentation now that the item has a media icon

## Why

The close action under Feedback & Support was the only menu action without an icon. Its placeholder indentation also pushed the label farther right than neighboring items.

## Validation

- production mobile build: document editor
- production mobile build: spreadsheet editor
- production mobile build: presentation editor
- production mobile build: Visio editor
- `git diff --check`
