### PR TITLE
fix(mobile): don't crash in uk/pl locales due to undefined license warning translation

### DIFF
--- a/apps/documenteditor/forms/app/controller/ApplicationController.js
+++ b/apps/documenteditor/forms/app/controller/ApplicationController.js
@@ -189,9 +189,9 @@ define([
 
             window.onbeforeunload = _.bind(this.onBeforeUnload, this);
 
-            this.warnNoLicense  = this.warnNoLicense.replace(/%1/g, '{{COMPANY_NAME}}');
-            this.warnNoLicenseUsers = this.warnNoLicenseUsers.replace(/%1/g, '{{COMPANY_NAME}}');
-            this.textNoLicenseTitle = this.textNoLicenseTitle.replace(/%1/g, '{{COMPANY_NAME}}');
+            this.warnNoLicense  = (this.warnNoLicense || "warnNoLicense").replace(/%1/g, '{{COMPANY_NAME}}');
+            this.warnNoLicenseUsers = (this.warnNoLicenseUsers || "warnNoLicenseUsers").replace(/%1/g, '{{COMPANY_NAME}}');
+            this.textNoLicenseTitle = (this.textNoLicenseTitle || "textNoLicenseTitle").replace(/%1/g, '{{COMPANY_NAME}}');
         },
 
         onDocumentResize: function() {

--- a/apps/documenteditor/mobile/src/controller/Main.jsx
+++ b/apps/documenteditor/mobile/src/controller/Main.jsx
@@ -710,9 +710,9 @@ class MainController extends Component {
         const { t } = this.props;
         const _t = t('Main', {returnObjects:true});
 
-        const warnNoLicense  = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
-        const warnNoLicenseUsers = _t.warnNoLicenseUsers.replace(/%1/g, __COMPANY_NAME__);
-        const textNoLicenseTitle = _t.textNoLicenseTitle.replace(/%1/g, __COMPANY_NAME__);
+        const warnNoLicense  = (_t.warnNoLicense || "warnNoLicense").replace(/%1/g, __COMPANY_NAME__);
+        const warnNoLicenseUsers = (_t.warnNoLicenseUsers || "warnNoLicenseUsers").replace(/%1/g, __COMPANY_NAME__);
+        const textNoLicenseTitle = (_t.textNoLicenseTitle || "textNoLicenseTitle").replace(/%1/g, __COMPANY_NAME__);
 
         const appOptions = this.props.storeAppOptions;
         const isForm = appOptions.isForm;

--- a/apps/presentationeditor/mobile/src/controller/Main.jsx
+++ b/apps/presentationeditor/mobile/src/controller/Main.jsx
@@ -683,9 +683,9 @@ class MainController extends Component {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
 
-        const warnNoLicense  = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
-        const warnNoLicenseUsers = _t.warnNoLicenseUsers.replace(/%1/g, __COMPANY_NAME__);
-        const textNoLicenseTitle = _t.textNoLicenseTitle.replace(/%1/g, __COMPANY_NAME__);
+        const warnNoLicense  = (_t.warnNoLicense || "warnNoLicense").replace(/%1/g, __COMPANY_NAME__);
+        const warnNoLicenseUsers = (_t.warnNoLicenseUsers || "warnNoLicenseUsers").replace(/%1/g, __COMPANY_NAME__);
+        const textNoLicenseTitle = (_t.textNoLicenseTitle || "textNoLicenseTitle").replace(/%1/g, __COMPANY_NAME__);
 
         const appOptions = this.props.storeAppOptions;
         if (appOptions.config.mode !== 'view' && !EditorUIController.isSupportEditFeature()) {

--- a/apps/spreadsheeteditor/mobile/src/controller/Main.jsx
+++ b/apps/spreadsheeteditor/mobile/src/controller/Main.jsx
@@ -864,9 +864,9 @@ class MainController extends Component {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
 
-        const warnNoLicense = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
-        const warnNoLicenseUsers = _t.warnNoLicenseUsers.replace(/%1/g, __COMPANY_NAME__);
-        const textNoLicenseTitle = _t.textNoLicenseTitle.replace(/%1/g, __COMPANY_NAME__);
+        const warnNoLicense = (_t.warnNoLicense || "warnNoLicense").replace(/%1/g, __COMPANY_NAME__);
+        const warnNoLicenseUsers = (_t.warnNoLicenseUsers || "warnNoLicenseUsers").replace(/%1/g, __COMPANY_NAME__);
+        const textNoLicenseTitle = (_t.textNoLicenseTitle || "textNoLicenseTitle").replace(/%1/g, __COMPANY_NAME__);
 
         const appOptions = this.props.storeAppOptions;
         if (appOptions.config.mode !== 'view' && !EditorUIController.isSupportEditFeature()) {

--- a/apps/visioeditor/mobile/src/controller/Main.jsx
+++ b/apps/visioeditor/mobile/src/controller/Main.jsx
@@ -417,9 +417,9 @@ class MainController extends Component {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
 
-        const warnNoLicense  = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
-        const warnNoLicenseUsers = _t.warnNoLicenseUsers.replace(/%1/g, __COMPANY_NAME__);
-        const textNoLicenseTitle = _t.textNoLicenseTitle.replace(/%1/g, __COMPANY_NAME__);
+        const warnNoLicense  = (_t.warnNoLicense || "warnNoLicense").replace(/%1/g, __COMPANY_NAME__);
+        const warnNoLicenseUsers = (_t.warnNoLicenseUsers || "warnNoLicenseUsers").replace(/%1/g, __COMPANY_NAME__);
+        const textNoLicenseTitle = (_t.textNoLicenseTitle || "textNoLicenseTitle").replace(/%1/g, __COMPANY_NAME__);
 
         const appOptions = this.props.storeAppOptions;
         if (appOptions.config.mode !== 'view' && !EditorUIController.isSupportEditFeature()) {


### PR DESCRIPTION
Resolves #161, resolves Euro-Office/eurooffice-nextcloud#93. A proper fix would be to translate the missing strings to Ukrainian and Polish, but from what I see Euro-Office doesn't have documented translation infrastructure yet. This is a major bug - e.g. presentations fail to open for every local user of Nextcloud app, so a workaround is better than nothing.