### PR TITLE
test(unit-tests): make the harness runnable again

### DIFF
--- a/test/unit-tests/common.js
+++ b/test/unit-tests/common.js
@@ -33,8 +33,29 @@
 
 // Include and setup all the stuff for testing
 define([
-    'chai'
+    'chai',
+    'backbone'
 ],function(chai) {
     window.expect = chai.expect;
     window.assert = chai.assert;
+
+    // Components read a little ambient state at render time -- Button asks
+    // Common.UI.Scaling for the current ratio, and the menus ask Common.Locale
+    // for the text direction. Pulling in the real modules would drag 'core' and
+    // the whole application bootstrap into a unit test, so stub the two calls.
+    window.Common = window.Common || {};
+    Common.UI = Common.UI || {};
+    Common.UI.Scaling = Common.UI.Scaling || {};
+    if (!Common.UI.Scaling.currentRatio) {
+        Common.UI.Scaling.currentRatio = function() { return 1; };
+    }
+    Common.Locale = Common.Locale || {};
+    if (!Common.Locale.isCurrentLanguageRtl) {
+        Common.Locale.isCurrentLanguageRtl = function() { return false; };
+    }
+    // Components subscribe to app-wide events (uitheme:changed, modal:close)
+    // on render. Backbone.Events is the same thing the application installs.
+    if (!Common.NotificationCenter) {
+        Common.NotificationCenter = _.extend({}, Backbone.Events);
+    }
 });

--- a/test/unit-tests/common/index.html
+++ b/test/unit-tests/common/index.html
@@ -3,23 +3,29 @@
 <head>
     <meta charset="utf-8">
     <title>Unit Tests</title>
-    <link rel="stylesheet" href="../../../../web-apps%20—%20копия/build/node_modules/mocha/mocha.css" type="text/css" media="screen" title="no title" charset="utf-8">
+    <link rel="stylesheet" href="../../../build/node_modules/mocha/mocha.css" type="text/css" media="screen" title="no title" charset="utf-8">
 </head>
 <body>
 <div id="mocha"></div>
-<script src="../../../../web-apps%20—%20копия/build/node_modules/mocha/mocha.js" type="text/javascript" charset="utf-8"></script>
-<script src="../../../../web-apps%20—%20копия/vendor/requirejs/require.js" type="text/javascript" charset="utf-8"></script>
+<script src="../../../build/node_modules/mocha/mocha.js" type="text/javascript" charset="utf-8"></script>
+<script src="../../../vendor/requirejs/require.js" type="text/javascript" charset="utf-8"></script>
 
-<script type="text/javascript" charset="utf-8">
+<script type="module">
+    // chai 5.x ships ESM only, so it cannot be pulled in by requirejs.
+    // Import it here and register it under the id the test files already use,
+    // so define(['chai']) and require('chai') keep working unchanged.
+    import * as chai from '../../../build/node_modules/chai/chai.js';
+    window.chai = chai;
+    define('chai', [], function () { return chai; });
+
     // Partial config file
     require.config({
         // Base URL relative to the test runner
         // Paths are relative to this
-        baseUrl: '../../apps/',
+        baseUrl: '../../../apps/',
         paths: {
             // Testing libs
             'common'            : 'common',
-            'chai'              : '../build/node_modules/chai/chai',
             'jquery'            : '../vendor/jquery/jquery.min',
             'underscore'        : '../vendor/underscore/underscore',
             'backbone'          : '../vendor/backbone/backbone',
@@ -64,8 +70,7 @@
 
     // You can do this in the grunt config for each mocha task, see the `options` config
     mocha.setup({
-        ui: 'bdd',
-        ignoreLeaks: true
+        ui: 'bdd'
     });
 
     // Protect from barfs
@@ -79,11 +84,23 @@
         mocha.run();
     };
 
-    require([
-        '../test/common',
-        './main/lib/util/utils.js',
-        '../../test/common/main/lib/component/Button.js'
-    ], runMocha);
+    // The app modules under test read $, _ and Backbone as globals rather than
+    // declaring them as dependencies, so requirejs is free to evaluate them
+    // before the vendor libs land. Load the globals first, then the tests.
+    require(['jquery', 'underscore', 'backbone'], function ($, _, Backbone) {
+        // underscore's UMD build registers itself as an AMD module and leaves
+        // no global behind, so publish the three the app modules expect.
+        window.$ = window.jQuery = $;
+        window._ = _;
+        window.Backbone = Backbone;
+
+        require([
+            '../test/unit-tests/common',
+            './main/lib/util/utils.js',
+            './main/lib/component/Button.js',
+            './main/lib/util/SmartPicker.js'
+        ], runMocha);
+    });
 </script>
 </body>
 </html>

--- a/test/unit-tests/common/index.html
+++ b/test/unit-tests/common/index.html
@@ -94,12 +94,16 @@
         window._ = _;
         window.Backbone = Backbone;
 
-        require([
-            '../test/unit-tests/common',
-            './main/lib/util/utils.js',
-            './main/lib/component/Button.js',
-            './main/lib/util/SmartPicker.js'
-        ], runMocha);
+        // The test setup module publishes assert/expect and stubs the ambient
+        // Common.* state the components read at render time. A flat require
+        // array would let requirejs evaluate whichever module lands first, so
+        // wait for the setup to finish before the tests are pulled in.
+        require(['../test/unit-tests/common'], function () {
+            require([
+                './main/lib/util/utils.js',
+                './main/lib/component/Button.js'
+            ], runMocha);
+        });
     });
 </script>
 </body>

--- a/test/unit-tests/common/main/lib/component/Button.js
+++ b/test/unit-tests/common/main/lib/component/Button.js
@@ -35,8 +35,8 @@
 
 define([
     'backbone',
-    '../../../../../../../web-apps — копия/apps/common/main/lib/component/Button.js',
-    '../../../../../apps/common/main/lib/component/Menu.js'
+    'common/main/lib/component/Button',
+    'common/main/lib/component/Menu'
 ],function() {
     var chai    = require('chai'),
         should  = chai.should();
@@ -70,7 +70,7 @@ define([
             button.caption.should.equal('update caption');
 
             // dom
-            assert.equal(button.cmpEl.find('button:first').andSelf().filter('button').text(), 'update caption', 'dom caption');
+            assert.equal(button.cmpEl.find('button:first').addBack().filter('button').text(), 'update caption', 'dom caption');
         });
 
         it('Button toggle', function(){

--- a/test/unit-tests/common/main/lib/util/utils.js
+++ b/test/unit-tests/common/main/lib/util/utils.js
@@ -34,7 +34,7 @@
  */
 
 define([
-    '../../../../../../../web-apps — копия/apps/common/main/lib/util/utils.js'
+    'common/main/lib/util/utils'
 ],function() {
     describe('Common.Utils.String', function(){
         it('Test format', function(){


### PR DESCRIPTION
## Make the unit-test harness runnable again

`test/unit-tests/common/index.html` could not run at all. Every path in it, and in
the two test files it loads, pointed into a `web-apps — копия` directory that is not
in this repository. RequireJS aborts the whole run on the first 404, so the suite has
been dead long enough for the rest of it to rot behind that.

### Fixed
- **Paths** resolve inside this checkout. `baseUrl` was `'../../apps/'`, which from
  `test/unit-tests/common/` is `test/apps/` — a directory that has never existed.
- **`mocha.setup()`** no longer passes `ignoreLeaks`. Removed in mocha 4, and
  `setup()` calls every key as a method, so an unknown one throws
  `self[opt] is not a function` before a single test registers.
- **chai 5 is ESM-only** (`"type": "module"`, no UMD build), so RequireJS's classic
  script tag dies on `export`. The page imports it as a module and registers it under
  the id the test files already use, leaving `define(['chai'])` and `require('chai')`
  untouched.
- **jquery / underscore / backbone** load before the tests and are published to
  `window`. The components read them as globals without declaring them as
  dependencies, and underscore's UMD build registers as AMD without leaving a global
  behind, so RequireJS was free to evaluate a component first.
- **`.js`-suffixed module ids** resolve against the page rather than `baseUrl` — the
  ids inside the test files lost their extension, the ones in `index.html` kept theirs.
- **The test setup module loads before the suites.** It publishes `assert`/`expect`
  and stubs the ambient `Common.*` state, and it sat in the same flat `require` array
  as the suites that read them. RequireJS documents no ordering guarantee for
  independent siblings in one array, so the call is nested — the same pattern already
  used for the vendor globals one level up.

### And the Button suite, which was failing on its own terms
- `.andSelf()` was removed in jQuery 3; it is `.addBack()` now.
- `Common.UI.Scaling.currentRatio()`, `Common.Locale.isCurrentLanguageRtl()` and
  `Common.NotificationCenter` are read at render time. The real modules pull in `core`
  and the whole application bootstrap, which is the opposite of a unit test, so
  `common.js` stubs the three.

### Result
**12 tests, no failures.** Serve the repository over http and open
`test/unit-tests/common/index.html` — RequireJS cannot load modules from `file://`,
where Chrome gives every URL its own opaque origin.

No product code is touched.

### No longer depends on #130
The SmartPicker suite registration moved to #130, which is where the module
(`apps/common/main/lib/util/SmartPicker.js`) and its test file come from. This branch
now stands on its own and the two can merge in either order; whichever lands second
resolves a one-line conflict in the `require` array.

Assisted-by: ClaudeCode:claude-opus-5
