### PR TITLE
fix: convert static <i> icons of el-bound buttons to SVG sprite references

### DIFF
--- a/apps/common/main/lib/component/Button.js
+++ b/apps/common/main/lib/component/Button.js
@@ -469,6 +469,17 @@ define([
                     parentEl.html(me.cmpEl);
                     me.$icon = me.$el.find('.icon');
                 }
+            } else if (!me.rendered) {
+                // SVG sprite approach (see templateBtnIcon): buttons bound to an
+                // existing element via `el` never run the template, so their static
+                // <i class="icon toolbar__icon btn-*"> markup survives — but the css
+                // sprite classes it relied on are gone. Convert it here the same way
+                // the template does, keeping fragment-only references.
+                me.cmpEl.find('i.icon.toolbar__icon').each(function () {
+                    var iconMatch = /btn-[^\s]+/.exec(this.className);
+                    if (iconMatch)
+                        $(this).replaceWith('<svg class="icon uni-scale"><use href="#' + iconMatch[0] + '"></use></svg>');
+                });
             }
 
             if (!me.rendered) {


### PR DESCRIPTION
Fixes #196.

Buttons bound to existing markup via `el` skip `templateBtnIcon`, so their static `<i class="icon toolbar__icon btn-*">` elements were left relying on css sprite classes that the SVG migration removed — functional but invisible buttons (spreadsheet status bar: add worksheet, sheet list, tab prev/next, zoom +/-).

This adds the missing half of the migration in `Button.render()`: static icons are converted with the same `/btn-[^\s]+/` extraction and fragment-only `<use>` references the template uses. 11 lines, no behavior change for template-rendered buttons.

Tested: macOS arm64 + Windows x64 desktop builds, spreadsheet/document/presentation/pdf editors rebuilt with the patch; icons render in all themes tried (light/dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
