### PR TITLE
PostMessage: add mentions via WOPI

### DIFF
--- a/apps/api/wopi/editor-wopi.ejs
+++ b/apps/api/wopi/editor-wopi.ejs
@@ -129,6 +129,23 @@ div {
                     "images": [{ "url": data.Values.url }]
                 });
             },
+            'Action_SetUsers': function (data) {
+                //response to UI_RequestUsers; "c" is echoed back by the host so the editor can
+                //route the list to the request that asked for it. Each user needs both "email"
+                //and "name" or Common.UI.ExternalUsers drops it from the list; "hasAccess"
+                //sorts users who can already open the file above a separator, "image" is the
+                //optional avatar. isPaginated must be present to keep the editor in
+                //server-side-search mode (undefined switches it to "fetch once, filter locally").
+                data && data.Values && docEditor.setUsers({
+                    "c": data.Values.c,
+                    "users": data.Values.users,
+                    "isPaginated": data.Values.isPaginated
+                });
+            },
+            'Action_SetActionLink': function (data) {
+                //response to UI_MakeActionLink; setActionLink takes the url as a bare string
+                data && data.Values && docEditor.setActionLink(data.Values.url);
+            },
             'Host_PostmessageReady': function (data) {
                 innerAlert('Host_PostmessageReady');
             }
@@ -248,6 +265,42 @@ div {
         var onRequestInsertImage = function (event) {
             insertImageType = event.data.c;
             _postMessage('UI_InsertGraphic', {});
+        };
+
+        var onRequestUsers = function (event) {
+            //see Common.Gateway.requestUsers: "c" is the operation type (mention/protect/info),
+            //"id" carries the user ids to resolve for c==="info", and from/count/search describe
+            //the mention autocomplete query. Forwarding search/from/count lets the host search
+            //server-side; it must then answer with isPaginated set, otherwise
+            //Common.UI.ExternalUsers caches the first response and never asks again.
+            _postMessage('UI_RequestUsers', {
+                "c": event.data.c,
+                "id": event.data.id,
+                "from": event.data.from,
+                "count": event.data.count,
+                "search": event.data.search
+            });
+        };
+
+        var onRequestSendNotify = function (event) {
+            //event.data is Comments.js' pickEMail payload: the emails are parsed out of the
+            //comment text, so they are exactly the ones the host handed over in Action_SetUsers
+            _postMessage('UI_SendNotify', {
+                "actionLink": event.data.actionLink,
+                "actionId": event.data.actionId,
+                "message": event.data.message,
+                "emails": event.data.emails
+            });
+        };
+
+        var onMakeActionLink = function (event) {
+            //event.data is {action: {type: "bookmark"|"internallink", data: <bookmark name|sheet!range>}};
+            //the host turns it into a document url carrying that anchor, and answers
+            //Action_SetActionLink. Comment links do not come through here - Comments.js builds those
+            //itself and passes them along with UI_SendNotify.
+            _postMessage('UI_MakeActionLink', {
+                "config": event.data
+            });
         };
 
         var onError = function (event) {
@@ -405,9 +458,28 @@ div {
                     "onRequestRename": fileInfo.SupportsRename && fileInfo.UserCanRename ? onRequestRename : undefined,
                     "onRequestSharingSettings": fileInfo.FileSharingPostMessage || fileInfo.FileSharingUrl ? onRequestSharingSettings : undefined,
                     "onRequestHistory": fileInfo.FileVersionUrl || fileInfo.FileVersionPostMessage ? onRequestHistory : undefined,
-                    "onRequestInsertImage": fileInfo.EnableInsertRemoteImage ? onRequestInsertImage : undefined
+                    "onRequestInsertImage": fileInfo.EnableInsertRemoteImage ? onRequestInsertImage : undefined,
+                    //onRequestUsers also answers c==="info" avatar lookups, which fire for every
+                    //user - gating it on comment rights would leave viewers without avatars
+                    "onRequestUsers": fileInfo.UserMentionPostMessage ? onRequestUsers : undefined,
+                    //the @/+ prompt follows onRequestSendNotify, so comment rights are checked here
+                    "onRequestSendNotify": permissionsComment && fileInfo.UserMentionPostMessage ? onRequestSendNotify : undefined,
+                    //"copy link to this comment/bookmark". Not gated on comment rights: bookmark
+                    //links are useful to a read-only reader too.
+                    "onMakeActionLink": fileInfo.UserMentionPostMessage ? onMakeActionLink : undefined
                 }
 			});
+
+            //Deep link into a comment/bookmark: the other half of onMakeActionLink and of the
+            //mention notifications. Set after the merges rather than inside them, so an absent
+            //param doesn't clobber an actionLink the host supplied via docs_api_config.
+            if (queryParams.actionlink) {
+                try {
+                    config.editorConfig.actionLink = JSON.parse(queryParams.actionlink);
+                } catch (e) {
+                    innerAlert("Ignoring malformed actionlink parameter");
+                }
+            }
 
             postMessageOrigin = fileInfo.PostMessageOrigin || "*";
             if (postMessageOrigin && (typeof postMessageOrigin === 'string') && postMessageOrigin.charAt(postMessageOrigin.length-1)=='/')

--- a/apps/api/wopi/editor-wopi.ejs
+++ b/apps/api/wopi/editor-wopi.ejs
@@ -287,8 +287,10 @@ div {
         };
 
         var onRequestSendNotify = function (event) {
-            //event.data is Comments.js' pickEMail payload: the emails are parsed out of the
-            //comment text, so they are exactly the ones the host handed over in Action_SetUsers
+            //event.data is Comments.js' pickEMail payload, extracted via regex from the raw
+            //comment text - NOT validated against the list Action_SetUsers returned. a
+            //commenter can type any address here; hosts must validate "emails" against their
+            //own ACLs before sending, same as any other client-supplied string in this file.
             _postMessage('UI_SendNotify', {
                 "actionLink": event.data.actionLink,
                 "actionId": event.data.actionId,

--- a/apps/api/wopi/editor-wopi.ejs
+++ b/apps/api/wopi/editor-wopi.ejs
@@ -273,6 +273,10 @@ div {
             //the mention autocomplete query. Forwarding search/from/count lets the host search
             //server-side; it must then answer with isPaginated set, otherwise
             //Common.UI.ExternalUsers caches the first response and never asks again.
+            //this handler is gated only on UserMentionPostMessage, not on the requesting
+            //user's comment permission - c==="info" (avatars) is safe to answer for anyone,
+            //but c==="mention" is a searchable name+email directory and per-user
+            //comment-right checking is unenforced here.
             _postMessage('UI_RequestUsers', {
                 "c": event.data.c,
                 "id": event.data.id,


### PR DESCRIPTION
Hi

I work at CERN in the CERNBox team and we're about to start a EuroOffice pilot in CERNBox and mentions came up as a gap: opened through WOPI, the @/+ button never appears in the comment pane, because the host has no way to answer the editor's user-list request. The callbacks already exist in the editor - they're just not wired up in the WOPI page, which registers onRequestSharingSettings, onRequestHistory and friends but stops short of the mention set.

All changes are in apps/api/wopi/editor-wopi.ejs; nothing in the editors themselves changes. It adds three exchanges between the editor and the host:

- when the user types @, the editor asks the host who it can suggest, and the host answers with a list of names and emails
- when the comment is posted, the editor hands the host the message, the mentioned addresses and a link anchor for that comment, so the host can send the notification
- "Get Link" - on a bookmark in Documents, on a cell range in Spreadsheets - asks the host for a url pointing at that spot

Hosts opt in with a new CheckFileInfo property, UserMentionPostMessage, the same way FileSharingPostMessage switches on the sharing button today - hosts that don't set it see exactly today's behaviour. Mentions are also hidden from users who can't comment. "Get Link" isn't, since that's useful to a read-only reader too.

This has been tested with our [wopiserver](https://github.com/cs3org/wopiserver/).