### PR TITLE
Remove Google Analytics script loader

### DIFF
--- a/apps/common/Analytics.js
+++ b/apps/common/Analytics.js
@@ -27,52 +27,11 @@ if (window.Common === undefined)
 
 Common.component = Common.component || {};
 
+    // Analytics has been removed. The API is retained as no-ops so existing
+    // call sites across the editors keep working until they are cleaned up.
     Common.Analytics = Common.component.Analytics = new(function() {
-        var _category;
-
         return {
-            initialize: function(id, category) {
-
-                if (typeof id === 'undefined')
-                    throw 'Analytics: invalid id.';
-
-                if (typeof category === 'undefined' || Object.prototype.toString.apply(category) !== '[object String]')
-                    throw 'Analytics: invalid category type.';
-
-                _category = category;
-
-                $('head').append(
-                    '<script type="text/javascript">' +
-                    'var _gaq = _gaq || [];' +
-                    '_gaq.push(["_setAccount", "' + id + '"]);' +
-                    '_gaq.push(["_trackPageview"]);' +
-                    '(function() {' +
-                    'var ga = document.createElement("script"); ga.type = "text/javascript"; ga.async = true;' +
-                    'ga.src = ("https:" == document.location.protocol ? "https://ssl" : "http://www") + ".google-analytics.com/ga.js";' +
-                    'var s = document.getElementsByTagName("script")[0]; s.parentNode.insertBefore(ga, s);' +
-                    '})();' +
-                    '</script>'
-                );
-            },
-
-            trackEvent: function(action, label, value) {
-
-                if (typeof action !== 'undefined' && Object.prototype.toString.apply(action) !== '[object String]')
-                    throw 'Analytics: invalid action type.';
-
-                if (typeof label !== 'undefined' && Object.prototype.toString.apply(label) !== '[object String]')
-                    throw 'Analytics: invalid label type.';
-
-                if (typeof value !== 'undefined' && !(Object.prototype.toString.apply(value) === '[object Number]' && isFinite(value)))
-                    throw 'Analytics: invalid value type.';
-
-                if (typeof _gaq === 'undefined')
-                    return;
-
-                if (_category === 'undefined')
-                    throw 'Analytics is not initialized.';
-
-                _gaq.push(['_trackEvent', _category, action, label, value]);
-            }
-        }
+            initialize: function() {},
+            trackEvent: function() {}
+        };
     })();


### PR DESCRIPTION
## Remove Google Analytics script loader

Strips the GA script injection from `apps/common/Analytics.js`. The public API is
retained as no-ops so the existing call sites across the editors keep working;
removing those follows in a separate change.

Refs #82

### What changed

- `initialize()` no longer appends the inline `<script>` that seeded `_gaq` and
  pulled in `google-analytics.com/ga.js`. Both methods are now empty.
- The argument validation went with the injection — there is nothing left to
  validate. Callers that passed a bad type used to get a `throw`; they now get
  silence, which is the intent: no call site should have to care.
- `$('head')` was this file's only jQuery dependency, so the module no longer
  touches the DOM or any global beyond `window.Common`.
- The license header is untouched.

### Why the call sites stay

`rg -i analytics apps/ --glob '!vendor'` returns ~530 hits across the three
editors. Removing them is mechanical, but folding it into this commit would bury
the handful of lines that actually matter behind a diff nobody can review. The
no-op shims keep every one of those call sites working, so this change stands on
its own and cannot break a build. The call-site cleanup lands separately.

### The loader was already dead

`initialize()` is guarded by `&& false` in each editor's `Main.js`, so `ga.js`
was never injected in the first place. This commit removes code that had already
stopped running — it is not a behaviour change for users, only a removal of the
dead path and the third-party URL baked into it.

### Relation to #85
#85 does this in full — loader, call sites, `canAnalytics` flags, build config,
HTML loaders (74 files, `+12 −781`). It is the better end state and stays open;
I will close this if it lands.

It is not mergeable today: open ~2 months, no review, no CI, and `main` has moved
165 commits since — including Grunt → webpack. It edits `build/appforms.json` and
`build/Gruntfile.js`, which no longer exist, so it cannot be rebased. This change
touches one file for that reason, and removes the part that carries the risk.


### Testing
- `node --check apps/common/Analytics.js` — clean.
- Loaded the module in node (`global.window = global`) and called
  `trackEvent()` before `initialize()`, then `initialize()`, then
  `Common.component.Analytics.trackEvent()` — no throw, and both aliases still
  resolve to the same object.
- `rg "_gaq" apps/ --glob '!vendor'` — no matches.
- `test/unit-tests/common/index.html` (per #194): 12 passing, unchanged. Note
  the harness has no coverage for this file — `rg -i analytics test/` is empty —
  so it confirms no regression elsewhere, not that this file works.