### PR TITLE
fix(license): stop enforcing licence restrictions in the editors

### DIFF
--- a/apps/common/main/lib/controller/Chat.js
+++ b/apps/common/main/lib/controller/Chat.js
@@ -114,7 +114,7 @@ define([
         },
 
         onUsersChanged: function(users, currentUserId){
-            if (!this.mode.canLicense || !this.mode.canCoAuthoring) {
+            if (!this.mode.canCoAuthoring) {
                 var len = 0;
                 for (name in users) {
                     if (undefined !== name) len++;

--- a/apps/common/mobile/lib/controller/collaboration/Collaboration.jsx
+++ b/apps/common/mobile/lib/controller/collaboration/Collaboration.jsx
@@ -26,7 +26,7 @@ class CollaborationController extends Component {
         const appOptions = this.props.storeAppOptions;
         /** coauthoring begin **/
         let isFastCoauth;
-        if (appOptions.isEdit && appOptions.canLicense && !appOptions.isOffline && appOptions.canCoAuthoring) {
+        if (appOptions.isEdit && !appOptions.isOffline && appOptions.canCoAuthoring) {
             // Force ON fast co-authoring mode
             isFastCoauth = true;
             api.asc_SetFastCollaborative(isFastCoauth);

--- a/apps/common/mobile/lib/view/About.jsx
+++ b/apps/common/mobile/lib/view/About.jsx
@@ -8,8 +8,7 @@ const PageAbout = props => {
     const { t } = useTranslation();
     const _t = t("About", { returnObjects: true });
     const store = props.storeAppOptions;
-    const isCanBranding = store.canBranding;
-    const licInfo = isCanBranding ? store.customization : null;
+    const licInfo = store.customization;
     const customer = licInfo ? licInfo.customer : null;
     const {
         name: nameCustomer = null,

--- a/apps/documenteditor/embed/js/ApplicationController.js
+++ b/apps/documenteditor/embed/js/ApplicationController.js
@@ -682,25 +682,9 @@ DE.ApplicationController = new(function(){
     }
 
     function onEditorPermissions(params) {
-        var licType = params.asc_getLicenseType();
-        if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-            Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                common.controller.modals.showWarning({
-                    title: Asc.c_oLicenseResult.NotBefore === licType ? me.titleLicenseNotActive : me.titleLicenseExp,
-                    message: Asc.c_oLicenseResult.NotBefore === licType ? me.warnLicenseBefore : me.warnLicenseExp,
-                    buttons: []
-                });
-        
-                $('#dlg-warning').css('z-index', 20002);
-                $('#dlg-warning button.close, #dlg-warning .modal-footer').remove();
-            return;
-        }
-
-        appOptions.canLicense     = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
         appOptions.canFillForms   = false; // use forms editor for filling forms
-        appOptions.canSubmitForms = appOptions.canLicense && (typeof (config.customization) == 'object') && !!config.customization.submitForm;
-        appOptions.canBranding  = params.asc_getCustomization();
-        appOptions.canBranding && setBranding(config.customization);
+        appOptions.canSubmitForms = (typeof (config.customization) == 'object') && !!config.customization.submitForm;
+        setBranding(config.customization);
 
         var type = /^(?:(docxf|oform))$/.exec(docConfig.fileType);
         appOptions.isOForm = !!(type && typeof type[1] === 'string'); // oform and docxf
@@ -1208,10 +1192,6 @@ DE.ApplicationController = new(function(){
         errorInconsistentExtPptx: 'An error has occurred while opening the file.<br>The file content corresponds to presentations (e.g. pptx), but the file has the inconsistent extension: %1.',
         errorInconsistentExtPdf: 'An error has occurred while opening the file.<br>The file content corresponds to one of the following formats: pdf/djvu/xps/oxps, but the file has the inconsistent extension: %1.',
         errorInconsistentExt: 'An error has occurred while opening the file.<br>The file content does not match the file extension.',
-        titleLicenseExp: 'License expired',
-        titleLicenseNotActive: 'License not active',
-        warnLicenseBefore: 'License not active. Please contact your administrator.',
-        warnLicenseExp: 'Your license has expired. Please update your license and refresh the page.',
         textConvertFormDownload: 'Download file as a fillable PDF form to be able to fill it out.',
         textDownloadPdf: 'Download pdf',
         errorToken: 'The document security token is not correctly formed.<br>Please contact your Document Server administrator.',

--- a/apps/documenteditor/forms/app/controller/ApplicationController.js
+++ b/apps/documenteditor/forms/app/controller/ApplicationController.js
@@ -816,7 +816,7 @@ define([
             Common.NotificationCenter.trigger('api:disconnect');
         },
 
-        applyLicense: function() {
+        applyRestrictions: function() {
             if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                 this.api.asc_coAuthoringDisconnect();
                 Common.NotificationCenter.trigger('api:disconnect');
@@ -1596,7 +1596,7 @@ define([
             this.updateWindowTitle(true);
 
             if (this.editorConfig.mode !== 'view') // if want to open editor, but viewer is loaded
-                this.applyLicense();
+                this.applyRestrictions();
 
             Common.Gateway.on('processmouse',       _.bind(this.onProcessMouse, this));
             Common.Gateway.on('downloadas',         _.bind(this.onDownloadAs, this));

--- a/apps/documenteditor/forms/app/controller/ApplicationController.js
+++ b/apps/documenteditor/forms/app/controller/ApplicationController.js
@@ -77,7 +77,7 @@ define([
                 weakCompare     : function(obj1, obj2){return obj1.type === obj2.type;}
             });
 
-            this._state = {isDisconnected: false, licenseType: false, isDocModified: false, isFormDisconnected: false};
+            this._state = {isDisconnected: false, isDocModified: false, isFormDisconnected: false};
             this._isDisabled = false;
 
             this.view = this.createView('ApplicationView').render();
@@ -188,10 +188,6 @@ define([
             });
 
             window.onbeforeunload = _.bind(this.onBeforeUnload, this);
-
-            this.warnNoLicense  = this.warnNoLicense.replace(/%1/g, '{{COMPANY_NAME}}');
-            this.warnNoLicenseUsers = this.warnNoLicenseUsers.replace(/%1/g, '{{COMPANY_NAME}}');
-            this.textNoLicenseTitle = this.textNoLicenseTitle.replace(/%1/g, '{{COMPANY_NAME}}');
         },
 
         onDocumentResize: function() {
@@ -623,7 +619,6 @@ define([
 
             this.api.asc_registerCallback('asc_onGetEditorPermissions', _.bind(this.onEditorPermissions, this));
             this.api.asc_registerCallback('asc_onRunAutostartMacroses', _.bind(this.onRunAutostartMacroses, this));
-            this.api.asc_registerCallback('asc_onLicenseChanged',       _.bind(this.onLicenseChanged, this));
             this.api.asc_setDocInfo(docInfo);
             this.api.asc_getEditorPermissions(this.editorConfig.licenseUrl, this.editorConfig.customerId);
             this.api.asc_enableKeyEvents(true);
@@ -638,20 +633,6 @@ define([
         },
 
         onEditorPermissions: function(params) {
-            var licType = params.asc_getLicenseType();
-            if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                Common.UI.warning({
-                    title: Asc.c_oLicenseResult.NotBefore === licType ? this.titleLicenseNotActive : this.titleLicenseExp,
-                    msg: Asc.c_oLicenseResult.NotBefore === licType ? this.warnLicenseBefore : this.warnLicenseExp,
-                    buttons: [],
-                    closable: false
-                });
-                if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                    Common.NotificationCenter.trigger('api:disconnect');
-                }
-                return;
-            }
 
             if ( this.onServerVersion(params.asc_getBuildVersion())) return;
             if ( this._isDocReady || this._isPermissionsInited ) {
@@ -664,20 +645,17 @@ define([
                 this.permissions.edit = this.permissions.review = false;
 
             this.appOptions.isOffline      = this.api.asc_isOffline();
-            this.appOptions.trialMode      = params.asc_getLicenseMode();
             this.appOptions.isBeta         = params.asc_getIsBeta();
-            this.appOptions.canLicense     = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
-            this.appOptions.canSubmitForms = this.appOptions.canLicense && (typeof (this.editorConfig.customization) == 'object') && !this.appOptions.isOffline &&
+            this.appOptions.canSubmitForms = (typeof (this.editorConfig.customization) == 'object') && !this.appOptions.isOffline &&
                                             !!this.editorConfig.customization.submitForm && (typeof this.editorConfig.customization.submitForm !== 'object' || this.editorConfig.customization.submitForm.visible!==false);
 
             var type = /^(?:(pdf))$/.exec(this.document.fileType); // can fill forms only in pdf format
             this.appOptions.isOFORM = !!(type && typeof type[1] === 'string');
-            this.appOptions.canFillForms = this.appOptions.canLicense && this.appOptions.isOFORM && ((this.permissions.fillForms===undefined) ? (this.permissions.edit !== false) : this.permissions.fillForms) &&
+            this.appOptions.canFillForms = this.appOptions.isOFORM && ((this.permissions.fillForms===undefined) ? (this.permissions.edit !== false) : this.permissions.fillForms) &&
                                            (this.editorConfig.mode !== 'view') && !this._state.isFormDisconnected;
             this.api.asc_setViewMode(!this.appOptions.canFillForms);
 
-            this.appOptions.canBranding  = params.asc_getCustomization();
-            this.appOptions.canBranding && this.setBranding(this.appOptions.customization);
+            this.setBranding(this.appOptions.customization);
 
             this.appOptions.canDownload       = this.permissions.download !== false;
             this.appOptions.canPrint          = (this.permissions.print !== false);
@@ -838,17 +816,6 @@ define([
             Common.NotificationCenter.trigger('api:disconnect');
         },
 
-        onLicenseChanged: function(params) {
-            var licType = params.asc_getLicenseType();
-            if (licType !== undefined && this.appOptions.canFillForms &&
-                (licType===Asc.c_oLicenseResult.Connections || licType===Asc.c_oLicenseResult.UsersCount || licType===Asc.c_oLicenseResult.ConnectionsOS || licType===Asc.c_oLicenseResult.UsersCountOS
-                    || licType===Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-                this._state.licenseType = licType;
-
-            if (this._isDocReady)
-                this.applyLicense();
-        },
-
         applyLicense: function() {
             if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                 this.api.asc_coAuthoringDisconnect();
@@ -857,45 +824,6 @@ define([
                     title: this.notcriticalErrorTitle,
                     msg  : this.warnLicenseAnonymous,
                     buttons: ['ok']
-                });
-            } else if (this._state.licenseType) {
-                var license = this._state.licenseType,
-                    title = this.textNoLicenseTitle,
-                    buttons = ['ok'],
-                    primary = 'ok',
-                    modal = false;
-                if ((this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                    (license===Asc.c_oLicenseResult.SuccessLimit || this.appOptions.permissionsLicense===Asc.c_oLicenseResult.SuccessLimit)) {
-                    license = this.warnLicenseLimitedRenewed;
-                } else if (license===Asc.c_oLicenseResult.Connections || license===Asc.c_oLicenseResult.UsersCount) {
-                    title = this.titleReadOnly;
-                    license = (license===Asc.c_oLicenseResult.Connections) ? this.tipLicenseExceeded : this.tipLicenseUsersExceeded;
-                } else {
-                    license = (license===Asc.c_oLicenseResult.ConnectionsOS) ? this.warnNoLicense : this.warnNoLicenseUsers;
-                    buttons = [{value: 'buynow', caption: this.textBuyNow}, {value: 'contact', caption: this.textContactUs}];
-                    primary = 'buynow';
-                    modal = true;
-                }
-
-                if (this._state.licenseType!==Asc.c_oLicenseResult.SuccessLimit && this.appOptions.canFillForms) {
-                    this.api.asc_coAuthoringDisconnect();
-                    Common.NotificationCenter.trigger('api:disconnect');
-                }
-
-                !modal ? Common.UI.TooltipManager.showTip({ step: 'licenseError', text: license, header: title, target: '#toolbar', maxwidth: 430,
-                        automove: true, noHighlight: true, noArrow: true, textButton: this.textContinue}) :
-                Common.UI.info({
-                    maxwidth: 500,
-                    title: title,
-                    msg  : license,
-                    buttons: buttons,
-                    primary: primary,
-                    callback: function(btn) {
-                        if (btn == 'buynow')
-                            window.open('{{PUBLISHER_URL}}', "_blank");
-                        else if (btn == 'contact')
-                            window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                    }
                 });
             }
         },
@@ -1810,15 +1738,13 @@ define([
                 this.view.menuItemsDarkMode.setChecked(Common.UI.Themes.isContentThemeDark());
             }
 
-            if (this.appOptions.canBranding) {
-                var value = this.appOptions.customization;
-                if ( value && value.logo && (value.logo.image || value.logo.imageDark || value.logo.imageLight)) {
-                    var image = Common.UI.Themes.isDarkTheme() ? (value.logo.imageDark || value.logo.image || value.logo.imageLight) :
-                                                                 (value.logo.imageLight || value.logo.image || value.logo.imageDark);
-                    if (_logoImage !== image) {
-                        _logoImage = image;
-                        $('#header-logo img').attr('src', image);
-                    }
+            var value = this.appOptions.customization;
+            if ( value && value.logo && (value.logo.image || value.logo.imageDark || value.logo.imageLight)) {
+                var image = Common.UI.Themes.isDarkTheme() ? (value.logo.imageDark || value.logo.image || value.logo.imageLight) :
+                                                             (value.logo.imageLight || value.logo.image || value.logo.imageDark);
+                if (_logoImage !== image) {
+                    _logoImage = image;
+                    $('#header-logo img').attr('src', image);
                 }
             }
         },
@@ -2392,13 +2318,6 @@ define([
         errorServerVersion: 'The editor version has been updated. The page will be reloaded to apply the changes.',
         titleUpdateVersion: 'Version changed',
         errorUpdateVersion: 'The file version has been changed. The page will be reloaded.',
-        warnLicenseLimitedRenewed: 'License needs to be renewed.<br>You have a limited access to document editing functionality.<br>Please contact your administrator to get full access',
-        warnLicenseLimitedNoAccess: 'License expired.<br>You have no access to document editing functionality.<br>Please contact your administrator.',
-        warnNoLicense: "You've reached the limit for simultaneous connections to %1 editors. This document will be opened for viewing only.<br>Contact %1 sales team for personal upgrade terms.",
-        warnNoLicenseUsers: "You've reached the user limit for %1 editors. Contact %1 sales team for personal upgrade terms.",
-        textBuyNow: 'Visit website',
-        textNoLicenseTitle: 'License limit reached',
-        textContactUs: 'Contact sales',
         errorLoadingFont: 'Fonts are not loaded.<br>Please contact your Document Server administrator.',
         errorConnectToServer: 'The document could not be saved. Please check connection settings or contact your administrator.<br>When you click the \'OK\' button, you will be prompted to download the document.',
         errorTokenExpire: 'The document security token has expired.<br>Please contact your Document Server administrator.',
@@ -2425,24 +2344,16 @@ define([
         errorEditingSaveas: 'An error occurred during the work with the document.<br>Use the \'Save as...\' option to save the file backup copy to your computer hard drive.',
         textSaveAs: 'Save as PDF',
         textSaveAsDesktop: 'Save as...',
-        warnLicenseExp: 'Your license has expired.<br>Please update your license and refresh the page.',
-        titleLicenseExp: 'License expired',
         errorTextFormWrongFormat: 'The value entered does not match the format of the field.',
         errorInconsistentExtDocx: 'An error has occurred while opening the file.<br>The file content corresponds to text documents (e.g. docx), but the file has the inconsistent extension: %1.',
         errorInconsistentExtXlsx: 'An error has occurred while opening the file.<br>The file content corresponds to spreadsheets (e.g. xlsx), but the file has the inconsistent extension: %1.',
         errorInconsistentExtPptx: 'An error has occurred while opening the file.<br>The file content corresponds to presentations (e.g. pptx), but the file has the inconsistent extension: %1.',
         errorInconsistentExtPdf: 'An error has occurred while opening the file.<br>The file content corresponds to one of the following formats: pdf/djvu/xps/oxps, but the file has the inconsistent extension: %1.',
         errorInconsistentExt: 'An error has occurred while opening the file.<br>The file content does not match the file extension.',
-        warnLicenseBefore: 'License not active.<br>Please contact your administrator.',
-        titleLicenseNotActive: 'License not active',
         warnLicenseAnonymous: 'Access denied for anonymous users. This document will be opened for viewing only.',
         textSubmitOk: 'Your PDF form has been saved in the Complete section. You can fill out this form again and send another result.',
         textFilled: 'Filled',
         savingText: 'Saving',
-        tipLicenseExceeded: 'The document is open in read-only mode as the maximum number of simultaneous connections allowed by license has been reached.<br><br>Please try again later or contact the document owner if you need editing access.',
-        tipLicenseUsersExceeded: 'The document is open in read-only mode as the maximum number of users allowed to edit documents by license has been reached.<br><br>Please try again later or contact the document owner if you need editing access.',
-        titleReadOnly: 'Read-Only Mode',
-        textContinue: 'Continue',
         txtSignedForm: 'This document has been signed and cannot be edited.',
         errorCopyDisabled: 'For security reasons, the contents of this document cannot be copied to the clipboard.'
 

--- a/apps/documenteditor/main/app/controller/Main.js
+++ b/apps/documenteditor/main/app/controller/Main.js
@@ -176,7 +176,7 @@ define([
 
                 this.stackMacrosRequests = [];
 
-                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, licenseType: false, isDocModified: false, requireUserAction: true};
+                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, isDocModified: false, requireUserAction: true};
                 this.languages = null;
 
                 // Initialize viewport
@@ -389,9 +389,6 @@ define([
                 }
 
                 me.defaultTitleText = '{{APP_TITLE_TEXT}}';
-                me.warnNoLicense  = (me.warnNoLicense || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.warnNoLicenseUsers = (me.warnNoLicenseUsers || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.textNoLicenseTitle = (me.textNoLicenseTitle || '').replace(/%1/g, '{{COMPANY_NAME}}');
             },
 
             loadConfig: function(data) {
@@ -592,7 +589,6 @@ define([
                 this.appOptions.isOForm = !!(type && typeof type[1] === 'string'); // oform and docxf
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', _.bind(this.onEditorPermissions, this));
-                this.api.asc_registerCallback('asc_onLicenseChanged',       _.bind(this.onLicenseChanged, this));
                 this.api.asc_registerCallback('asc_onMacrosPermissionRequest', _.bind(this.onMacrosPermissionRequest, this));
                 this.api.asc_registerCallback('asc_onRunAutostartMacroses', _.bind(this.onRunAutostartMacroses, this));
                 this.api.asc_setDocInfo(docInfo);
@@ -1458,8 +1454,7 @@ define([
 
                 leftmenuController.getView('LeftMenu').disableMenu('all',false);
 
-                if (me.appOptions.canBranding)
-                    me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
+                me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
 
                 documentHolderController.getView().on('editcomplete', _.bind(me.onEditComplete, me));
 
@@ -1563,26 +1558,9 @@ define([
                     this.getApplication().getController('LeftMenu').leftMenu.showMenu('file:saveas');
             },
 
-            onLicenseChanged: function(params) {
-                var licType = params.asc_getLicenseType();
-                if (licType !== undefined && (this.appOptions.canEdit || this.appOptions.isRestrictedEdit) && this.editorConfig.mode !== 'view' &&
-                   (licType===Asc.c_oLicenseResult.Connections || licType===Asc.c_oLicenseResult.UsersCount || licType===Asc.c_oLicenseResult.ConnectionsOS || licType===Asc.c_oLicenseResult.UsersCountOS
-                   || licType===Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-                    this._state.licenseType = licType;
-
-                if (licType !== undefined && this.appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                                                             licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-                    this._state.licenseType = licType;
-
-                if (this._isDocReady)
-                    this.applyLicense();
-            },
-
             applyLicense: function() {
                 if (this.editorConfig.mode === 'view') {
-                    if (this.appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                                        this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                                                        !this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous)) {
+                    if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("de-settings-coauthmode") was true ???
                         this.disableLiveViewing(true);
                     }
@@ -1595,59 +1573,6 @@ define([
                         msg  : this.warnLicenseAnonymous,
                         buttons: ['ok']
                     });
-                } else if (this._state.licenseType) {
-                    var license = this._state.licenseType,
-                        title = this.textNoLicenseTitle,
-                        buttons = ['ok'],
-                        primary = 'ok',
-                        modal = false;
-                    if ((this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                        (license===Asc.c_oLicenseResult.SuccessLimit || this.appOptions.permissionsLicense===Asc.c_oLicenseResult.SuccessLimit)) {
-                        license = this.warnLicenseLimitedRenewed;
-                    } else if (license===Asc.c_oLicenseResult.Connections || license===Asc.c_oLicenseResult.UsersCount) {
-                        title = this.titleReadOnly;
-                        license = (license===Asc.c_oLicenseResult.Connections) ? this.tipLicenseExceeded : this.tipLicenseUsersExceeded;
-                    } else {
-                        license = (license===Asc.c_oLicenseResult.ConnectionsOS) ? this.warnNoLicense : this.warnNoLicenseUsers;
-                        buttons = [{value: 'buynow', caption: this.textBuyNow}, {value: 'contact', caption: this.textContactUs}];
-                        primary = 'buynow';
-                        modal = true;
-                    }
-
-                    if (this._state.licenseType!==Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.isEdit || this.appOptions.isRestrictedEdit)) {
-                        this.disableEditing(true);
-                        this.api.asc_coAuthoringDisconnect();
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-
-                    !modal ? Common.UI.TooltipManager.showTip({ step: 'licenseError', text: license, header: title, target: '#toolbar', maxwidth: 430,
-                                                                      automove: true, noHighlight: true, noArrow: true, textButton: this.textContinue}) :
-                    Common.UI.info({
-                        maxwidth: 500,
-                        title: title,
-                        msg  : license,
-                        buttons: buttons,
-                        primary: primary,
-                        callback: function(btn) {
-                            if (btn == 'buynow')
-                                window.open('{{PUBLISHER_URL}}', "_blank");
-                            else if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
-                    });
-                } else if (!this.appOptions.isDesktopApp && !this.appOptions.canBrandingExt &&
-                            this.editorConfig && this.editorConfig.customization && (this.editorConfig.customization.loaderName || this.editorConfig.customization.loaderLogo ||
-                            this.editorConfig.customization.font && (this.editorConfig.customization.font.size || this.editorConfig.customization.font.name))) {
-                    Common.UI.warning({
-                        title: this.textPaidFeature,
-                        msg  : this.textCustomLoader,
-                        buttons: [{value: 'contact', caption: this.textContactUs}, {value: 'close', caption: this.textClose}],
-                        primary: 'contact',
-                        callback: function(btn) {
-                            if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
-                    });
                 }
             },
 
@@ -1659,21 +1584,6 @@ define([
             },
 
             onEditorPermissions: function(params) {
-                var licType = params.asc_getLicenseType();
-                if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                    Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                    Common.UI.warning({
-                        title: Asc.c_oLicenseResult.NotBefore === licType ? this.titleLicenseNotActive : this.titleLicenseExp,
-                        msg: Asc.c_oLicenseResult.NotBefore === licType ? this.warnLicenseBefore : this.warnLicenseExp,
-                        buttons: [],
-                        closable: false
-                    });
-                    if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                        this.disableEditing(true);
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-                    return;
-                }
                 if ( this.onServerVersion(params.asc_getBuildVersion()) || !this.onLanguageLoaded() ) return;
                 if ( this._isDocReady || this._isPermissionsInited ) {
                     this.api.asc_LoadDocument();
@@ -1687,9 +1597,7 @@ define([
                 if (params.asc_getRights() !== Asc.c_oRights.Edit)
                     this.permissions.edit = this.permissions.review = false;
 
-                this.appOptions.permissionsLicense = licType;
                 this.appOptions.canAnalytics   = params.asc_getIsAnalyticsEnable();
-                this.appOptions.canLicense     = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
                 this.appOptions.isLightVersion = params.asc_getIsLight();
                 /** coauthoring begin **/
                 this.appOptions.canCoAuthoring = !this.appOptions.isLightVersion;
@@ -1700,25 +1608,24 @@ define([
                 this.appOptions.isReviewOnly   = this.permissions.review === true && this.permissions.edit === false;
                 this.appOptions.canRequestEditRights = this.editorConfig.canRequestEditRights;
                 this.appOptions.canEdit        = (this.permissions.edit !== false || this.permissions.review === true) && // can edit or review
-                                                 (this.editorConfig.canRequestEditRights || this.editorConfig.mode !== 'view') && // if mode=="view" -> canRequestEditRights must be defined
-                                                 (!this.appOptions.isReviewOnly || this.appOptions.canLicense); // if isReviewOnly==true -> canLicense must be true
-                this.appOptions.isEdit         = this.appOptions.canLicense && this.appOptions.canEdit && this.editorConfig.mode !== 'view';
-                this.appOptions.canReview      = this.permissions.review === true && this.appOptions.canLicense && this.appOptions.isEdit;
+                                                 (this.editorConfig.canRequestEditRights || this.editorConfig.mode !== 'view'); // if mode=="view" -> canRequestEditRights must be defined
+                this.appOptions.isEdit         = this.appOptions.canEdit && this.editorConfig.mode !== 'view';
+                this.appOptions.canReview      = this.permissions.review === true && this.appOptions.isEdit;
                 this.appOptions.canViewReview  = true;
-                this.appOptions.canUseHistory  = this.appOptions.canLicense && this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
+                this.appOptions.canUseHistory  = this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
                 this.appOptions.canHistoryClose  = this.editorConfig.canHistoryClose;
                 this.appOptions.canHistoryRestore= this.editorConfig.canHistoryRestore;
-                this.appOptions.canUseMailMerge= this.appOptions.canLicense && this.appOptions.canEdit && !this.appOptions.isOffline;
-                this.appOptions.canSendEmailAddresses  = this.appOptions.canLicense && this.editorConfig.canSendEmailAddresses && this.appOptions.canEdit && this.appOptions.canCoAuthoring;
-                this.appOptions.canComments    = this.appOptions.canLicense && (this.permissions.comment===undefined ? this.appOptions.isEdit : this.permissions.comment) && (this.editorConfig.mode !== 'view');
+                this.appOptions.canUseMailMerge= this.appOptions.canEdit && !this.appOptions.isOffline;
+                this.appOptions.canSendEmailAddresses  = this.editorConfig.canSendEmailAddresses && this.appOptions.canEdit && this.appOptions.canCoAuthoring;
+                this.appOptions.canComments    = (this.permissions.comment===undefined ? this.appOptions.isEdit : this.permissions.comment) && (this.editorConfig.mode !== 'view');
                 this.appOptions.canComments    = !isPDFViewer && this.appOptions.canComments && !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
                 this.appOptions.canViewComments = this.appOptions.canComments || !isPDFViewer && !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
-                this.appOptions.canChat        = this.appOptions.canLicense && !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
+                this.appOptions.canChat        = !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
                                                                                                                (typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat===false);
                 if ((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat!==undefined) {
                     console.log("Obsolete: The 'chat' parameter of the 'customization' section is deprecated. Please use 'chat' parameter in the permissions instead.");
                 }
-                this.appOptions.canEditStyles  = this.appOptions.canLicense && this.appOptions.canEdit;
+                this.appOptions.canEditStyles  = this.appOptions.canEdit;
                 this.appOptions.canPrint       = (this.permissions.print !== false);
                 this.appOptions.canPreviewPrint = this.appOptions.canPrint && !Common.Utils.isMac && this.appOptions.isDesktopApp;
                 this.appOptions.canQuickPrint = this.appOptions.canPrint && !Common.Utils.isMac && this.appOptions.isDesktopApp;
@@ -1750,7 +1657,7 @@ define([
                 this.appOptions.canProtect     = (this.permissions.protect!==false);
                 this.appOptions.canEditContentControl = (this.permissions.modifyContentControl!==false);
                 this.appOptions.canHelp        = false; // temporarily disabled — was: !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.help===false);
-                this.appOptions.canFillForms   = this.appOptions.canLicense && (this.appOptions.isEdit ? true : this.permissions.fillForms) && (this.editorConfig.mode !== 'view');
+                this.appOptions.canFillForms   = (this.appOptions.isEdit ? true : this.permissions.fillForms) && (this.editorConfig.mode !== 'view');
                 this.appOptions.isRestrictedEdit = !this.appOptions.isEdit && (this.appOptions.canComments || this.appOptions.canFillForms);
                 this.appOptions.canSaveToFile = this.appOptions.isEdit || this.appOptions.isRestrictedEdit;
                 this.appOptions.canDownloadOrigin = false;
@@ -1768,7 +1675,7 @@ define([
                 if (this.appOptions.isRestrictedEdit && this.appOptions.canComments && this.appOptions.canFillForms) // must be one restricted mode, priority for filling forms
                     this.appOptions.canComments = false;
                 this.appOptions.canSwitchMode  = this.appOptions.isEdit;
-                this.appOptions.canSubmitForms = this.appOptions.isRestrictedEdit && this.appOptions.canFillForms && this.appOptions.canLicense && !this.appOptions.isOffline && (typeof (this.editorConfig.customization) == 'object') &&
+                this.appOptions.canSubmitForms = this.appOptions.isRestrictedEdit && this.appOptions.canFillForms && !this.appOptions.isOffline && (typeof (this.editorConfig.customization) == 'object') &&
                                                 !!this.editorConfig.customization.submitForm && (typeof this.editorConfig.customization.submitForm !== 'object' || this.editorConfig.customization.submitForm.visible!==false);
                 this.appOptions.canStartFilling = this.editorConfig.canStartFilling && this.appOptions.isEdit &&  this.appOptions.isPDFForm; // show Start Filling button in the header
 
@@ -1787,7 +1694,7 @@ define([
 
                 // var type = /^(?:(djvu))$/.exec(this.document.fileType);
                 this.appOptions.canUseSelectHandTools = this.appOptions.canUseThumbnails = this.appOptions.canUseViwerNavigation = isPDFViewer;
-                this.appOptions.canDownloadForms = false && this.appOptions.canLicense && this.appOptions.canDownload && this.appOptions.isRestrictedEdit && this.appOptions.canFillForms; // don't show download form button in edit mode
+                this.appOptions.canDownloadForms = false && this.appOptions.canDownload && this.appOptions.isRestrictedEdit && this.appOptions.canFillForms; // don't show download form button in edit mode
 
                 this.appOptions.fileKey = this.document.key;
 
@@ -1797,17 +1704,15 @@ define([
 
                 Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!
 
-                this.appOptions.canBranding  = params.asc_getCustomization();
-                if (this.appOptions.canBranding)
-                    appHeader.setBranding(this.editorConfig.customization, this.appOptions);
+                appHeader.setBranding(this.editorConfig.customization, this.appOptions);
 
                 this.appOptions.canFavorite = this.document.info && (this.document.info.favorite!==undefined && this.document.info.favorite!==null) && !this.appOptions.isOffline;
                 this.appOptions.canFavorite && appHeader.setFavorite(this.document.info.favorite);
 
-                this.appOptions.canUseReviewPermissions = this.appOptions.canLicense && (!!this.permissions.reviewGroups ||
+                this.appOptions.canUseReviewPermissions = (!!this.permissions.reviewGroups ||
                                                         this.editorConfig.customization && this.editorConfig.customization.reviewPermissions && (typeof (this.editorConfig.customization.reviewPermissions) == 'object'));
-                this.appOptions.canUseCommentPermissions = this.appOptions.canLicense && !!this.permissions.commentGroups;
-                this.appOptions.canUseUserInfoPermissions = this.appOptions.canLicense && !!this.permissions.userInfoGroups;
+                this.appOptions.canUseCommentPermissions = !!this.permissions.commentGroups;
+                this.appOptions.canUseUserInfoPermissions = !!this.permissions.userInfoGroups;
                 AscCommon.UserInfoParser.setParser(true);
                 AscCommon.UserInfoParser.setCurrentName(this.appOptions.user.fullname);
                 this.appOptions.canUseReviewPermissions && AscCommon.UserInfoParser.setReviewPermissions(this.permissions.reviewGroups, this.editorConfig.customization.reviewPermissions);
@@ -1827,7 +1732,7 @@ define([
                     Common.NotificationCenter.on('comments:showdummy', _.bind(this.onShowDummyComment, this));
 
                 // change = true by default in editor
-                this.appOptions.canLiveView = !!params.asc_getLiveViewerSupport() && (this.editorConfig.mode === 'view') && !isPDFViewer; // viewer: change=false when no flag canLiveViewer (i.g. old license), change=true by default when canLiveViewer==true
+                this.appOptions.canLiveView = (this.editorConfig.mode === 'view') && !isPDFViewer;
                 this.appOptions.canChangeCoAuthoring = this.appOptions.isEdit && this.appOptions.canCoAuthoring && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false) ||
                                                        this.appOptions.canLiveView && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false);
                 this.appOptions.isAnonymousSupport = !!this.api.asc_isAnonymousSupport();

--- a/apps/documenteditor/main/app/controller/Main.js
+++ b/apps/documenteditor/main/app/controller/Main.js
@@ -1504,7 +1504,7 @@ define([
                             me.api.UpdateInterfaceState();
 
                             Common.NotificationCenter.trigger('document:ready', 'main');
-                            me.applyLicense();
+                            me.applyRestrictions();
                         }
                     }, 50);
                 } else {
@@ -1520,7 +1520,7 @@ define([
                     toolbarController.createDelayedElementsViewer();
                     Common.Utils.injectSvgIcons();
                     Common.NotificationCenter.trigger('document:ready', 'main');
-                    me.applyLicense();
+                    me.applyRestrictions();
                 }
 
                 // TODO bug 43960
@@ -1558,7 +1558,7 @@ define([
                     this.getApplication().getController('LeftMenu').leftMenu.showMenu('file:saveas');
             },
 
-            applyLicense: function() {
+            applyRestrictions: function() {
                 if (this.editorConfig.mode === 'view') {
                     if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("de-settings-coauthmode") was true ???

--- a/apps/documenteditor/mobile/src/controller/Main.jsx
+++ b/apps/documenteditor/mobile/src/controller/Main.jsx
@@ -126,7 +126,6 @@ class MainController extends Component {
         });
 
         this._state = {
-            licenseType: false,
             isFromGatewayDownloadAs: false,
             isDocModified: false,
             docProtection: false,
@@ -257,7 +256,6 @@ class MainController extends Component {
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', onEditorPermissions);
                 this.api.asc_registerCallback('asc_onDocumentContentReady', onDocumentContentReady);
-                this.api.asc_registerCallback('asc_onLicenseChanged', this.onLicenseChanged.bind(this));
                 this.api.asc_registerCallback('asc_onMacrosPermissionRequest', this.onMacrosPermissionRequest.bind(this));
                 this.api.asc_registerCallback('asc_onRunAutostartMacroses', this.onRunAutostartMacroses.bind(this));
                 this.api.asc_setDocInfo(docInfo);
@@ -281,33 +279,11 @@ class MainController extends Component {
             };
 
             const onEditorPermissions = params => {
-                const licType = params.asc_getLicenseType();
-
-                const { t } = this.props;
-                const _t = t('Main', {returnObjects:true});
-                // check licType
-                if (Asc.c_oLicenseResult.Expired === licType ||
-                    Asc.c_oLicenseResult.Error === licType ||
-                    Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                    Asc.c_oLicenseResult.NotBefore === licType ||
-                    Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                    f7.dialog.create({
-                        title   : Asc.c_oLicenseResult.NotBefore === licType ? _t.titleLicenseNotActive : _t.titleLicenseExp,
-                        text    : Asc.c_oLicenseResult.NotBefore === licType ? _t.warnLicenseBefore : _t.warnLicenseExp
-                    }).open();
-                    if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                        Common.Notifications.trigger('api:disconnect');
-                    }
-                    return;
-                }
-
                 if ( this.onServerVersion(params.asc_getBuildVersion()) ) return;
                 if ( this._isDocReady || this._isPermissionsInited ) {
                     this.api.asc_LoadDocument();
                     return;
                 }
-
-                this.appOptions.canLicense = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
 
                 const storeAppOptions = this.props.storeAppOptions;
                 const editorConfig = window.native?.editorConfig;
@@ -325,7 +301,7 @@ class MainController extends Component {
                     console.warn("Obsolete: The mobileForceView parameter is deprecated. Please use the forceView parameter from customization.mobile block");
                 }
 
-                storeAppOptions.setPermissionOptions(this.document, licType, params, this.permissions, EditorUIController.isSupportEditFeature());
+                storeAppOptions.setPermissionOptions(this.document, params, this.permissions, EditorUIController.isSupportEditFeature());
 
                 this.applyMode(storeAppOptions);
 
@@ -689,33 +665,11 @@ class MainController extends Component {
             clearTimeout(this.continueSavingTimer);
     }
 
-    onLicenseChanged (params) {
-        const appOptions = this.props.storeAppOptions;
-        const licType = params.asc_getLicenseType();
-    
-        if (licType !== undefined && (appOptions.canEdit || appOptions.isRestrictedEdit) && appOptions.config.mode !== 'view' &&
-            (licType === Asc.c_oLicenseResult.Connections || licType === Asc.c_oLicenseResult.UsersCount || licType === Asc.c_oLicenseResult.ConnectionsOS || licType === Asc.c_oLicenseResult.UsersCountOS
-                || licType === Asc.c_oLicenseResult.SuccessLimit && (appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-            this._state.licenseType = licType;
-
-        if (licType !== undefined && appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                                                licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-            this._state.licenseType = licType;
-
-        if (this._isDocReady && this._state.licenseType)
-            this.applyLicense();
-    }
-
     applyLicense () {
         const { t } = this.props;
         const _t = t('Main', {returnObjects:true});
 
-        const warnNoLicense  = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
-        const warnNoLicenseUsers = _t.warnNoLicenseUsers.replace(/%1/g, __COMPANY_NAME__);
-        const textNoLicenseTitle = _t.textNoLicenseTitle.replace(/%1/g, __COMPANY_NAME__);
-
         const appOptions = this.props.storeAppOptions;
-        const isForm = appOptions.isForm;
 
         if (appOptions.config.mode !== 'view' && !EditorUIController.isSupportEditFeature()) {
             let value = LocalStorage.getItem("de-opensource-warning");
@@ -734,9 +688,7 @@ class MainController extends Component {
         }
 
         if (appOptions.config.mode === 'view') {
-            if (appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                            this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                                            !appOptions.isAnonymousSupport && !!appOptions.config.user.anonymous)) {
+            if (!appOptions.isAnonymousSupport && !!appOptions.config.user.anonymous) {
                 appOptions.canLiveView = false;
                 this.api.asc_SetFastCollaborative(false);
             }
@@ -751,64 +703,7 @@ class MainController extends Component {
                 text : _t.warnLicenseAnonymous,
                 buttons: [{ text: _t.textOk }]
             }).open();
-        } else if (this._state.licenseType) {
-            let license = this._state.licenseType;
-            let buttons = [{ text: _t.textOk }];
-            let title = textNoLicenseTitle;
-            if ((appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                (license === Asc.c_oLicenseResult.SuccessLimit ||
-                    appOptions.permissionsLicense === Asc.c_oLicenseResult.SuccessLimit)
-            ) {
-                license = _t.warnLicenseLimitedRenewed;
-            } else if (license === Asc.c_oLicenseResult.Connections || license === Asc.c_oLicenseResult.UsersCount) {
-                title = _t.titleReadOnly;
-                license = (license===Asc.c_oLicenseResult.Connections) ? _t.tipLicenseExceeded : _t.tipLicenseUsersExceeded;
-            } else {
-                license = (license === Asc.c_oLicenseResult.ConnectionsOS) ? warnNoLicense : warnNoLicenseUsers;
-                buttons = [{
-                    text: _t.textBuyNow,
-                    bold: true,
-                    onClick: function() {
-                        window.open(`${__PUBLISHER_URL__}`, "_blank");
-                    }
-                },
-                    {
-                        text: _t.textContactUs,
-                        onClick: function() {
-                            window.open(`mailto:${__SALES_EMAIL__}`, "_blank");
-                        }
-                    }];
-            }
-            if (this._state.licenseType === Asc.c_oLicenseResult.SuccessLimit) {
-                Common.Notifications.trigger('toolbar:activatecontrols');
-            } else {
-                Common.Notifications.trigger('toolbar:activatecontrols');
-                Common.Notifications.trigger('toolbar:deactivateeditcontrols');
-                this.api.asc_coAuthoringDisconnect();
-                Common.Notifications.trigger('api:disconnect');
-            }
-
-            f7.dialog.create({
-                title: title,
-                text : license,
-                buttons: buttons
-            }).open();
         } else {
-            if (!appOptions.isDesktopApp && !appOptions.canBrandingExt &&
-                appOptions.config && appOptions.config.customization && (appOptions.config.customization.loaderName || appOptions.config.customization.loaderLogo)) {
-                f7.dialog.create({
-                    title: _t.textPaidFeature,
-                    text  : _t.textCustomLoader,
-                    buttons: [{
-                        text: _t.textContactUs,
-                        bold: true,
-                        onClick: () => {
-                            window.open(`mailto:${__SALES_EMAIL__}`, "_blank");
-                        }
-                    },
-                        { text: _t.textClose }]
-                }).open();
-            }
             Common.Notifications.trigger('toolbar:activatecontrols');
         }
     }

--- a/apps/documenteditor/mobile/src/controller/Main.jsx
+++ b/apps/documenteditor/mobile/src/controller/Main.jsx
@@ -392,7 +392,7 @@ class MainController extends Component {
                 this.api.Resize();
                 this.api.zoomFitToWidth();
                 this.api.asc_GetDefaultTableStyles && setTimeout(() => {this.api.asc_GetDefaultTableStyles()}, 1);
-                this.applyLicense();
+                this.applyRestrictions();
 
                 Common.Notifications.trigger('document:ready');
                 Common.Gateway.documentReady();
@@ -665,7 +665,7 @@ class MainController extends Component {
             clearTimeout(this.continueSavingTimer);
     }
 
-    applyLicense () {
+    applyRestrictions () {
         const { t } = this.props;
         const _t = t('Main', {returnObjects:true});
 

--- a/apps/documenteditor/mobile/src/page/main.jsx
+++ b/apps/documenteditor/mobile/src/page/main.jsx
@@ -62,7 +62,7 @@ const MainPage = inject('storeDocumentInfo', 'users', 'storeAppOptions', 'storeV
 
     if(!appOptions.isDisconnected && appOptions.isDocReady) {
         const { logo } = customization;
-        isBranding = appOptions.canBranding || appOptions.canBrandingExt;
+        isBranding = appOptions.canBrandingExt;
         
         if(logo && isBranding) {
             isHideLogo = logo.visible === false;

--- a/apps/documenteditor/mobile/src/store/appOptions.js
+++ b/apps/documenteditor/mobile/src/store/appOptions.js
@@ -20,7 +20,6 @@ export class storeAppOptions {
             changeReaderMode: action,
 
             canBrandingExt: observable,
-            canBranding: observable,
 
             isDocReady: observable,
             changeDocReady: action,
@@ -105,7 +104,6 @@ export class storeAppOptions {
     }
 
     canBrandingExt = true;
-    canBranding = true;
 
     isDocReady = false;
     changeDocReady (value) {
@@ -178,12 +176,11 @@ export class storeAppOptions {
         AscCommon.UserInfoParser.setParser(true);
         AscCommon.UserInfoParser.setCurrentName(this.user.fullname);
     }
-    setPermissionOptions (document, licType, params, permissions, isSupportEditFeature) {
+    setPermissionOptions (document, params, permissions, isSupportEditFeature) {
         if (params.asc_getRights() !== Asc.c_oRights.Edit)
             permissions.edit = permissions.review = false;
         this.review = (permissions.review === undefined) ? (permissions.edit !== false) : permissions.review;
         this.canAnalytics = params.asc_getIsAnalyticsEnable();
-        this.canLicense = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
         this.isLightVersion = params.asc_getIsLight();
         this.buildVersion = params.asc_getBuildVersion();
         this.canCoAuthoring = !this.isLightVersion;
@@ -192,17 +189,16 @@ export class storeAppOptions {
         this.canRequestEditRights = this.config.canRequestEditRights;
         this.canEdit = (permissions.edit !== false || permissions.review === true) && // can edit or review
             (this.config.canRequestEditRights || this.config.mode !== 'view') && // if mode=="view" -> canRequestEditRights must be defined
-            (!this.isReviewOnly || this.canLicense) && // if isReviewOnly==true -> canLicense must be true
             isSupportEditFeature;
-        this.isEdit = this.canLicense && this.canEdit && this.config.mode !== 'view';
-        this.canReview = this.canLicense && this.isEdit && (permissions.review===true);
-        this.canUseHistory = this.canLicense && this.config.canUseHistory && this.canCoAuthoring && !this.isDesktopApp && !this.isOffline;
+        this.isEdit = this.canEdit && this.config.mode !== 'view';
+        this.canReview = this.isEdit && (permissions.review===true);
+        this.canUseHistory = this.config.canUseHistory && this.canCoAuthoring && !this.isDesktopApp && !this.isOffline;
         this.canRename = this.config.canRename;
         this.canHistoryClose = this.config.canHistoryClose;
         this.canHistoryRestore= this.config.canHistoryRestore;
-        this.canUseMailMerge = this.canLicense && this.canEdit && !this.isDesktopApp;
-        this.canSendEmailAddresses = this.canLicense && this.config.canSendEmailAddresses && this.canEdit && this.canCoAuthoring;
-        this.canComments = this.canLicense && (permissions.comment === undefined ? this.isEdit : permissions.comment) && (this.config.mode !== 'view');
+        this.canUseMailMerge = this.canEdit && !this.isDesktopApp;
+        this.canSendEmailAddresses = this.config.canSendEmailAddresses && this.canEdit && this.canCoAuthoring;
+        this.canComments = (permissions.comment === undefined ? this.isEdit : permissions.comment) && (this.config.mode !== 'view');
         this.canComments = this.canComments && !((typeof (this.customization) == 'object') && this.customization.comments===false);
         this.canViewComments = this.canComments || !((typeof (this.customization) == 'object') && this.customization.comments===false);
         this.canEditComments = this.isOffline || !permissions.editCommentAuthorOnly;
@@ -212,23 +208,22 @@ export class storeAppOptions {
             if (permissions.editCommentAuthorOnly===undefined && permissions.deleteCommentAuthorOnly===undefined)
                 this.canEditComments = this.canDeleteComments = this.isOffline;
         }
-        this.canChat = this.canLicense && !this.isOffline && (permissions.chat !== false);
-        this.canEditStyles = this.canLicense && this.canEdit;
+        this.canChat = !this.isOffline && (permissions.chat !== false);
+        this.canEditStyles = this.canEdit;
         this.canPrint = (permissions.print !== false);
         this.fileKey = document.key;
         this.isXpsViewer = /^(?:(djvu|xps|oxps))$/.exec(document.fileType);
         this.typeForm = document.fileType === 'pdf'; // can fill forms only in pdf format
         this.isOForm = document.fileType === 'oform';
-        this.canFillForms = this.canLicense && this.typeForm && ((permissions.fillForms === undefined) ? this.isEdit : permissions.fillForms) && (this.config.mode !== 'view');
+        this.canFillForms = this.typeForm && ((permissions.fillForms === undefined) ? this.isEdit : permissions.fillForms) && (this.config.mode !== 'view');
         this.isForm = !this.isXpsViewer && !!window.isPDFForm;
         this.canProtect = permissions.protect !== false;
-        this.canSubmitForms = this.canLicense && !this.isOffline && (typeof (this.customization) == 'object') && !!this.customization.submitForm &&
+        this.canSubmitForms = !this.isOffline && (typeof (this.customization) == 'object') && !!this.customization.submitForm &&
                               (typeof this.customization.submitForm !== 'object' || this.customization.submitForm.visible!==false);
         this.isEditableForms = this.isForm && this.canSubmitForms;
         this.isRestrictedEdit = !this.isEdit && (this.canComments || this.canFillForms) && isSupportEditFeature;
         if (this.isRestrictedEdit && this.canComments && this.canFillForms) // must be one restricted mode, priority for filling forms
             this.canComments = false;
-        this.trialMode = params.asc_getLicenseMode();
 
         const type = /^(?:(pdf|djvu|xps|oxps))$/.exec(document.fileType);
 
@@ -236,7 +231,6 @@ export class storeAppOptions {
         this.canDownload = permissions.download !== false;
         this.canReader = (!type || typeof type[1] !== 'string');
 
-        this.canBranding = params.asc_getCustomization();
         this.canBrandingExt = (typeof this.customization == 'object' || this.config.plugins);
 
         this.canFavorite = document.info && (document.info?.favorite !== undefined && document.info?.favorite !== null) && !this.isOffline;
@@ -245,15 +239,15 @@ export class storeAppOptions {
         if ( this.isLightVersion ) {
             this.canUseHistory = this.canReview = this.isReviewOnly = false;
         }
-        this.canUseReviewPermissions = this.canLicense && (!!permissions.reviewGroups || this.customization
+        this.canUseReviewPermissions = (!!permissions.reviewGroups || this.customization
             && this.customization.reviewPermissions && (typeof (this.customization.reviewPermissions) == 'object'));
-        this.canUseCommentPermissions = this.canLicense && !!permissions.commentGroups;
-        this.canUseUserInfoPermissions = this.canLicense && !!permissions.userInfoGroups;
+        this.canUseCommentPermissions = !!permissions.commentGroups;
+        this.canUseUserInfoPermissions = !!permissions.userInfoGroups;
         this.canUseReviewPermissions && AscCommon.UserInfoParser.setReviewPermissions(permissions.reviewGroups, this.customization.reviewPermissions);
         this.canUseCommentPermissions && AscCommon.UserInfoParser.setCommentPermissions(permissions.commentGroups);
         this.canUseUserInfoPermissions && AscCommon.UserInfoParser.setUserInfoPermissions(permissions.userInfoGroups);
 
-        this.canLiveView = !!params.asc_getLiveViewerSupport() && (this.config.mode === 'view') && !(type && typeof type[1] === 'string') && isSupportEditFeature;
+        this.canLiveView = (this.config.mode === 'view') && !(type && typeof type[1] === 'string') && isSupportEditFeature;
         this.isAnonymousSupport = !!Common.EditorApi.get().asc_isAnonymousSupport();
         this.canCopy = permissions.copy !== false;
     }

--- a/apps/pdfeditor/main/app/controller/Main.js
+++ b/apps/pdfeditor/main/app/controller/Main.js
@@ -124,7 +124,7 @@ define([
 
                 this.stackMacrosRequests = [];
 
-                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, licenseType: false, isDocModified: false, requireUserAction: true};
+                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, isDocModified: false, requireUserAction: true};
                 this.languages = null;
 
                 // Initialize viewport
@@ -338,9 +338,6 @@ define([
                 }
 
                 me.defaultTitleText = '{{APP_TITLE_TEXT}}';
-                me.warnNoLicense  = (me.warnNoLicense || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.warnNoLicenseUsers = (me.warnNoLicenseUsers || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.textNoLicenseTitle = (me.textNoLicenseTitle || '').replace(/%1/g, '{{COMPANY_NAME}}');
             },
 
             loadConfig: function(data) {
@@ -511,7 +508,6 @@ define([
                 }
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', _.bind(this.onEditorPermissions, this));
-                this.api.asc_registerCallback('asc_onLicenseChanged',       _.bind(this.onLicenseChanged, this));
                 this.api.asc_registerCallback('asc_onRunAutostartMacroses', _.bind(this.onRunAutostartMacroses, this));
                 this.api.asc_setDocInfo(docInfo);
                 this.api.asc_getEditorPermissions(this.editorConfig.licenseUrl, this.editorConfig.customerId);
@@ -1116,8 +1112,7 @@ define([
 
                 leftmenuController.getView('LeftMenu').disableMenu('all',false);
 
-                if (me.appOptions.canBranding)
-                    me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
+                me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
 
                 documentHolderController.getView().on('editcomplete', _.bind(me.onEditComplete, me));
 
@@ -1195,26 +1190,9 @@ define([
                     this.getApplication().getController('LeftMenu').leftMenu.showMenu('file:saveas');
             },
 
-            onLicenseChanged: function(params) {
-                var licType = params.asc_getLicenseType();
-                if (licType !== undefined && (this.appOptions.isPDFAnnotate || this.appOptions.isPDFFill || this.appOptions.isRestrictedEdit) &&
-                   (licType===Asc.c_oLicenseResult.Connections || licType===Asc.c_oLicenseResult.UsersCount || licType===Asc.c_oLicenseResult.ConnectionsOS || licType===Asc.c_oLicenseResult.UsersCountOS
-                   || licType===Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-                    this._state.licenseType = licType;
-
-                if (licType !== undefined && this.appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                    licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-                    this._state.licenseType = licType;
-
-                if (this._isDocReady)
-                    this.applyLicense();
-            },
-
             applyLicense: function() {
                 if (this.editorConfig.mode === 'view') {
-                    if (this.appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                        this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                        !this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous)) {
+                    if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("de-settings-coauthmode") was true ???
                         this.disableLiveViewing(true);
                     }
@@ -1227,59 +1205,6 @@ define([
                         msg  : this.warnLicenseAnonymous,
                         buttons: ['ok']
                     });
-                } else if (this._state.licenseType) {
-                    var license = this._state.licenseType,
-                        title = this.textNoLicenseTitle,
-                        buttons = ['ok'],
-                        primary = 'ok',
-                        modal = false;
-                    if ((this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                        (license===Asc.c_oLicenseResult.SuccessLimit || this.appOptions.permissionsLicense===Asc.c_oLicenseResult.SuccessLimit)) {
-                        license = this.warnLicenseLimitedRenewed;
-                    } else if (license===Asc.c_oLicenseResult.Connections || license===Asc.c_oLicenseResult.UsersCount) {
-                        title = this.titleReadOnly;
-                        license = (license===Asc.c_oLicenseResult.Connections) ? this.tipLicenseExceeded : this.tipLicenseUsersExceeded;
-                    } else {
-                        license = (license===Asc.c_oLicenseResult.ConnectionsOS) ? this.warnNoLicense : this.warnNoLicenseUsers;
-                        buttons = [{value: 'buynow', caption: this.textBuyNow}, {value: 'contact', caption: this.textContactUs}];
-                        primary = 'buynow';
-                        modal = true;
-                    }
-
-                    if (this._state.licenseType!==Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.isPDFFill || this.appOptions.isPDFAnnotate || this.appOptions.isPDFEdit || this.appOptions.isRestrictedEdit)) {
-                        this.disableEditing(true);
-                        this.api.asc_coAuthoringDisconnect();
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-
-                    !modal ? Common.UI.TooltipManager.showTip({ step: 'licenseError', text: license, header: title, target: '#toolbar', maxwidth: 430,
-                                                                automove: true, noHighlight: true, noArrow: true, textButton: this.textContinue}) :
-                        Common.UI.info({
-                            maxwidth: 500,
-                        title: title,
-                            msg  : license,
-                            buttons: buttons,
-                            primary: primary,
-                            callback: function(btn) {
-                                if (btn == 'buynow')
-                                    window.open('{{PUBLISHER_URL}}', "_blank");
-                                else if (btn == 'contact')
-                                    window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                            }
-                        });
-                } else if (!this.appOptions.isDesktopApp && !this.appOptions.canBrandingExt &&
-                    this.editorConfig && this.editorConfig.customization && (this.editorConfig.customization.loaderName || this.editorConfig.customization.loaderLogo ||
-                        this.editorConfig.customization.font && (this.editorConfig.customization.font.size || this.editorConfig.customization.font.name))) {
-                    Common.UI.warning({
-                        title: this.textPaidFeature,
-                        msg  : this.textCustomLoader,
-                        buttons: [{value: 'contact', caption: this.textContactUs}, {value: 'close', caption: this.textClose}],
-                        primary: 'contact',
-                        callback: function(btn) {
-                            if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
-                    });
                 }
             },
 
@@ -1291,21 +1216,6 @@ define([
             },
 
             onEditorPermissions: function(params) {
-                var licType = params.asc_getLicenseType();
-                if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                    Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                    Common.UI.warning({
-                        title: Asc.c_oLicenseResult.NotBefore === licType ? this.titleLicenseNotActive : this.titleLicenseExp,
-                        msg: Asc.c_oLicenseResult.NotBefore === licType ? this.warnLicenseBefore : this.warnLicenseExp,
-                        buttons: [],
-                        closable: false
-                    });
-                    if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                        this.disableEditing(true);
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-                    return;
-                }
 
                 if ( this.onServerVersion(params.asc_getBuildVersion()) || !this.onLanguageLoaded()) return;
                 if ( this._isDocReady || this._isPermissionsInited ) {
@@ -1318,9 +1228,7 @@ define([
 
                 this.appOptions.isXpsViewer = /^(?:(djvu|xps|oxps))$/.test(this.document.fileType) || Common.Locale.getDefaultLanguage() === 'ru';
                 this.appOptions.isForm = !this.appOptions.isXpsViewer && !!window.isPDFForm;
-                this.appOptions.permissionsLicense = licType;
                 this.appOptions.canAnalytics   = params.asc_getIsAnalyticsEnable();
-                this.appOptions.canLicense     = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
                 this.appOptions.isLightVersion = params.asc_getIsLight();
                 this.appOptions.canCoAuthoring = !this.appOptions.isLightVersion;
                 this.appOptions.isOffline      = this.api.asc_isOffline();
@@ -1331,23 +1239,23 @@ define([
                 var pdfEdit = !this.appOptions.isXpsViewer && !this.appOptions.isForm;
                 this.appOptions.canEdit = this.appOptions.isEdit = pdfEdit;
 
-                this.appOptions.canPDFAnnotate = pdfEdit && this.appOptions.canLicense && (this.permissions.edit!== false || this.permissions.comment!==false || this.appOptions.isDesktopApp && this.appOptions.isOffline);
+                this.appOptions.canPDFAnnotate = pdfEdit && (this.permissions.edit!== false || this.permissions.comment!==false || this.appOptions.isDesktopApp && this.appOptions.isOffline);
                 this.appOptions.isPDFAnnotate  = this.appOptions.canPDFAnnotate && (this.editorConfig.mode !== 'view');
-                this.appOptions.canPDFEdit     = pdfEdit && this.appOptions.canLicense && (this.permissions.edit !== false || this.appOptions.isDesktopApp && this.appOptions.isOffline);
+                this.appOptions.canPDFEdit     = pdfEdit && (this.permissions.edit !== false || this.appOptions.isDesktopApp && this.appOptions.isOffline);
                 this.appOptions.isPDFEdit      = false; // this.appOptions.canPDFEdit && this.editorConfig.mode !== 'view'; !! always open in view mode
                 // isPDFFill - can only fill forms, co-edit and save changes to file
-                this.appOptions.isPDFFill = pdfEdit && this.appOptions.canLicense && (this.permissions.fillForms!==false) && !this.appOptions.canPDFAnnotate && !this.appOptions.canPDFEdit && (this.editorConfig.mode !== 'view');
+                this.appOptions.isPDFFill = pdfEdit && (this.permissions.fillForms!==false) && !this.appOptions.canPDFAnnotate && !this.appOptions.canPDFEdit && (this.editorConfig.mode !== 'view');
                 this.appOptions.canSwitchMode = this.appOptions.isPDFAnnotate && this.appOptions.canPDFEdit; // switch between View/annotate and pdf edit
                 // this.appOptions.canCoEditing = (this.appOptions.isPDFAnnotate || this.appOptions.isPDFFill) && !(this.appOptions.isDesktopApp && this.appOptions.isOffline);
 
-                this.appOptions.canUseHistory  = pdfEdit && this.appOptions.canLicense && this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
+                this.appOptions.canUseHistory  = pdfEdit && this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
                 this.appOptions.canHistoryClose  = this.editorConfig.canHistoryClose;
                 this.appOptions.canHistoryRestore= this.editorConfig.canHistoryRestore;
 
-                this.appOptions.canComments    = pdfEdit && this.appOptions.canLicense && (this.permissions.comment===undefined ? this.appOptions.isPDFAnnotate : this.permissions.comment) && (this.editorConfig.mode !== 'view');
+                this.appOptions.canComments    = pdfEdit && (this.permissions.comment===undefined ? this.appOptions.isPDFAnnotate : this.permissions.comment) && (this.editorConfig.mode !== 'view');
                 this.appOptions.canComments    = this.appOptions.canComments && !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
                 this.appOptions.canViewComments = this.appOptions.canComments || pdfEdit && !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
-                this.appOptions.canChat        = this.appOptions.canLicense && !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
+                this.appOptions.canChat        = !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
                                                                                                                (typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat===false);
                 if ((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat!==undefined) {
                     console.log("Obsolete: The 'chat' parameter of the 'customization' section is deprecated. Please use 'chat' parameter in the permissions instead.");
@@ -1373,9 +1281,9 @@ define([
                 this.appOptions.isEditTextSupport = this.appOptions.isEdit;
                 this.appOptions.canProtect     = (this.permissions.protect!==false);
                 this.appOptions.canHelp        = false; // temporarily disabled — was: !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.help===false);
-                this.appOptions.canSubmitForms = this.appOptions.canLicense && (typeof (this.editorConfig.customization) == 'object') && !!this.editorConfig.customization.submitForm && !this.appOptions.isOffline;
+                this.appOptions.canSubmitForms = (typeof (this.editorConfig.customization) == 'object') && !!this.editorConfig.customization.submitForm && !this.appOptions.isOffline;
                 // TODO: check view mode
-                this.appOptions.canFillForms   = this.appOptions.canLicense && this.appOptions.isForm && ((this.permissions.fillForms===undefined) ? (this.permissions.edit !== false) : this.permissions.fillForms) && (this.editorConfig.mode !== 'view');
+                this.appOptions.canFillForms   = this.appOptions.isForm && ((this.permissions.fillForms===undefined) ? (this.permissions.edit !== false) : this.permissions.fillForms) && (this.editorConfig.mode !== 'view');
                 this.appOptions.isAnonymousSupport = !!this.api.asc_isAnonymousSupport();
                 this.appOptions.isRestrictedEdit = !this.appOptions.isEdit && this.appOptions.canFillForms;
                 this.appOptions.canSaveToFile = this.appOptions.isEdit && this.appOptions.isDesktopApp && this.appOptions.isOffline || this.appOptions.isRestrictedEdit ||
@@ -1403,15 +1311,13 @@ define([
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                 Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!
 
-                this.appOptions.canBranding  = params.asc_getCustomization();
-                if (this.appOptions.canBranding)
-                    appHeader.setBranding(this.editorConfig.customization, this.appOptions);
+                appHeader.setBranding(this.editorConfig.customization, this.appOptions);
 
                 this.appOptions.canFavorite = this.document.info && (this.document.info.favorite!==undefined && this.document.info.favorite!==null) && !this.appOptions.isOffline;
                 this.appOptions.canFavorite && appHeader.setFavorite(this.document.info.favorite);
 
-                this.appOptions.canUseCommentPermissions = this.appOptions.canLicense && !!this.permissions.commentGroups;
-                this.appOptions.canUseUserInfoPermissions = this.appOptions.canLicense && !!this.permissions.userInfoGroups;
+                this.appOptions.canUseCommentPermissions = !!this.permissions.commentGroups;
+                this.appOptions.canUseUserInfoPermissions = !!this.permissions.userInfoGroups;
                 AscCommon.UserInfoParser.setParser(true);
                 AscCommon.UserInfoParser.setCurrentName(this.appOptions.user.fullname);
                 this.appOptions.canUseCommentPermissions && AscCommon.UserInfoParser.setCommentPermissions(this.permissions.commentGroups);
@@ -1430,7 +1336,7 @@ define([
                     Common.NotificationCenter.on('comments:showdummy', _.bind(this.onShowDummyComment, this));
 
                 // change = true by default in editor
-                this.appOptions.canLiveView = !!params.asc_getLiveViewerSupport() && (this.editorConfig.mode === 'view') && !this.appOptions.isXpsViewer; // viewer: change=false when no flag canLiveViewer (i.g. old license), change=true by default when canLiveViewer==true
+                this.appOptions.canLiveView = (this.editorConfig.mode === 'view') && !this.appOptions.isXpsViewer;
                 this.appOptions.canChangeCoAuthoring = this.appOptions.isEdit && this.appOptions.canCoAuthoring && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false) ||
                                                         this.appOptions.canLiveView && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false);
 

--- a/apps/pdfeditor/main/app/controller/Main.js
+++ b/apps/pdfeditor/main/app/controller/Main.js
@@ -1141,12 +1141,12 @@ define([
                         me.api.UpdateInterfaceState();
 
                         Common.NotificationCenter.trigger('document:ready', 'main');
-                        me.applyLicense();
+                        me.applyRestrictions();
                     }, 500);
                 } else {
                     Common.NotificationCenter.trigger('document:ready', 'main');
                     Common.Utils.injectSvgIcons();
-                    me.applyLicense();
+                    me.applyRestrictions();
                 }
 
                 // TODO bug 43960
@@ -1190,7 +1190,7 @@ define([
                     this.getApplication().getController('LeftMenu').leftMenu.showMenu('file:saveas');
             },
 
-            applyLicense: function() {
+            applyRestrictions: function() {
                 if (this.editorConfig.mode === 'view') {
                     if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("de-settings-coauthmode") was true ???

--- a/apps/presentationeditor/embed/js/ApplicationController.js
+++ b/apps/presentationeditor/embed/js/ApplicationController.js
@@ -529,22 +529,7 @@ PE.ApplicationController = new(function(){
     }
 
     function onEditorPermissions(params) {
-        var licType = params.asc_getLicenseType();
-        if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-            Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                common.controller.modals.showWarning({
-                    title: Asc.c_oLicenseResult.NotBefore === licType ? me.titleLicenseNotActive : me.titleLicenseExp,
-                    message: Asc.c_oLicenseResult.NotBefore === licType ? me.warnLicenseBefore : me.warnLicenseExp,
-                    buttons: []
-                });
-        
-                $('#dlg-warning').css('z-index', 20002);
-                $('#dlg-warning button.close, #dlg-warning .modal-footer').remove();
-            return;
-        }
-
-        appOptions.canBranding  = params.asc_getCustomization();
-        appOptions.canBranding && setBranding(config.customization);
+        setBranding(config.customization);
 
         var $parent = labelDocName.parent();
         var _left_width = common.utils.getPosition($parent).left,
@@ -932,10 +917,6 @@ PE.ApplicationController = new(function(){
         errorInconsistentExtPptx: 'An error has occurred while opening the file.<br>The file content corresponds to presentations (e.g. pptx), but the file has the inconsistent extension: %1.',
         errorInconsistentExtPdf: 'An error has occurred while opening the file.<br>The file content corresponds to one of the following formats: pdf/djvu/xps/oxps, but the file has the inconsistent extension: %1.',
         errorInconsistentExt: 'An error has occurred while opening the file.<br>The file content does not match the file extension.',
-        titleLicenseExp: 'License expired',
-        titleLicenseNotActive: 'License not active',
-        warnLicenseBefore: 'License not active. Please contact your administrator.',
-        warnLicenseExp: 'Your license has expired. Please update your license and refresh the page.',
         errorEditingDownloadas: 'An error occurred during the work with the document.<br>Use the \'Download as...\' option to save the file backup copy to your computer hard drive.',
         errorToken: 'The document security token is not correctly formed.<br>Please contact your Document Server administrator.',
         txtPressLink: 'Click the link to open it',

--- a/apps/presentationeditor/main/app/controller/Main.js
+++ b/apps/presentationeditor/main/app/controller/Main.js
@@ -1076,14 +1076,14 @@ define([
                             me.api.UpdateInterfaceState();
 
                             Common.NotificationCenter.trigger('document:ready', 'main');
-                            me.applyLicense();
+                            me.applyRestrictions();
                         }
                     }, 50);
                 } else {
                     documentHolderController.getView().createDelayedElementsViewer();
                     Common.Utils.injectSvgIcons();
                     Common.NotificationCenter.trigger('document:ready', 'main');
-                    me.applyLicense();
+                    me.applyRestrictions();
                 }
 
                 // TODO bug 43960
@@ -1117,7 +1117,7 @@ define([
                     this.getApplication().getController('LeftMenu').leftMenu.showMenu('file:saveas');
             },
 
-            applyLicense: function() {
+            applyRestrictions: function() {
                 if (this.editorConfig.mode === 'view') {
                     if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("pe-settings-coauthmode") was true ???

--- a/apps/presentationeditor/main/app/controller/Main.js
+++ b/apps/presentationeditor/main/app/controller/Main.js
@@ -153,7 +153,7 @@ define([
             onLaunch: function() {
                 var me = this;
 
-                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, licenseType: false, isDocModified: false, requireUserAction: true};
+                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, isDocModified: false, requireUserAction: true};
                 this.languages = null;
 
                 window.storagename = 'presentation';
@@ -357,9 +357,6 @@ define([
                 }
 
                 me.defaultTitleText = '{{APP_TITLE_TEXT}}';
-                me.warnNoLicense  = (me.warnNoLicense || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.warnNoLicenseUsers = (me.warnNoLicenseUsers || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.textNoLicenseTitle = (me.textNoLicenseTitle || '').replace(/%1/g, '{{COMPANY_NAME}}');
             },
 
             loadConfig: function(data) {
@@ -532,7 +529,6 @@ define([
                 }
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', _.bind(this.onEditorPermissions, this));
-                this.api.asc_registerCallback('asc_onLicenseChanged',       _.bind(this.onLicenseChanged, this));
                 this.api.asc_registerCallback('asc_onMacrosPermissionRequest', _.bind(this.onMacrosPermissionRequest, this));
                 this.api.asc_registerCallback('asc_onRunAutostartMacroses', _.bind(this.onRunAutostartMacroses, this));
                 this.api.asc_setDocInfo(docInfo);
@@ -1032,8 +1028,7 @@ define([
 
                 leftmenuController.getView('LeftMenu').disableMenu('all',false);
 
-                if (me.appOptions.canBranding)
-                    me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
+                me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
 
                 documentHolderController.getView().on('editcomplete', _.bind(me.onEditComplete, me));
 //                if (me.isThumbnailsShow) me.getMainMenu().onThumbnailsShow(me.isThumbnailsShow);
@@ -1122,26 +1117,9 @@ define([
                     this.getApplication().getController('LeftMenu').leftMenu.showMenu('file:saveas');
             },
 
-            onLicenseChanged: function(params) {
-                var licType = params.asc_getLicenseType();
-                if (licType !== undefined && (this.appOptions.canEdit || this.appOptions.isRestrictedEdit) && this.editorConfig.mode !== 'view' &&
-                    (licType===Asc.c_oLicenseResult.Connections || licType===Asc.c_oLicenseResult.UsersCount || licType===Asc.c_oLicenseResult.ConnectionsOS || licType===Asc.c_oLicenseResult.UsersCountOS
-                    || licType===Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-                    this._state.licenseType = licType;
-
-                if (licType !== undefined && this.appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS||
-                                                                             licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-                    this._state.licenseType = licType;
-
-                if (this._isDocReady)
-                    this.applyLicense();
-            },
-
             applyLicense: function() {
                 if (this.editorConfig.mode === 'view') {
-                    if (this.appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                                        this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                                                        !this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous)) {
+                    if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("pe-settings-coauthmode") was true ???
                         this.disableLiveViewing(true);
                     }
@@ -1153,59 +1131,6 @@ define([
                         title: this.notcriticalErrorTitle,
                         msg  : this.warnLicenseAnonymous,
                         buttons: ['ok']
-                    });
-                } else if (this._state.licenseType) {
-                    var license = this._state.licenseType,
-                        title = this.textNoLicenseTitle,
-                        buttons = ['ok'],
-                        primary = 'ok',
-                        modal = false;
-                    if ((this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                        (license===Asc.c_oLicenseResult.SuccessLimit || this.appOptions.permissionsLicense===Asc.c_oLicenseResult.SuccessLimit)) {
-                        license = this.warnLicenseLimitedRenewed;
-                    } else if (license===Asc.c_oLicenseResult.Connections || license===Asc.c_oLicenseResult.UsersCount) {
-                        title = this.titleReadOnly;
-                        license = (license===Asc.c_oLicenseResult.Connections) ? this.tipLicenseExceeded : this.tipLicenseUsersExceeded;
-                    } else {
-                        license = (license===Asc.c_oLicenseResult.ConnectionsOS) ? this.warnNoLicense : this.warnNoLicenseUsers;
-                        buttons = [{value: 'buynow', caption: this.textBuyNow}, {value: 'contact', caption: this.textContactUs}];
-                        primary = 'buynow';
-                        modal = true;
-                    }
-
-                    if (this._state.licenseType!==Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.isEdit || this.appOptions.isRestrictedEdit)) {
-                        this.disableEditing(true);
-                        this.api.asc_coAuthoringDisconnect();
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-
-                    !modal ? Common.UI.TooltipManager.showTip({ step: 'licenseError', text: license, header: title, target: '#toolbar', maxwidth: 430,
-                                                                automove: true, noHighlight: true, noArrow: true, textButton: this.textContinue}) :
-                    Common.UI.info({
-                        maxwidth: 500,
-                        title: title,
-                        msg  : license,
-                        buttons: buttons,
-                        primary: primary,
-                        callback: function(btn) {
-                            if (btn == 'buynow')
-                                window.open('{{PUBLISHER_URL}}', "_blank");
-                            else if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
-                    });
-                } else if (!this.appOptions.isDesktopApp && !this.appOptions.canBrandingExt &&
-                    this.editorConfig && this.editorConfig.customization && (this.editorConfig.customization.loaderName || this.editorConfig.customization.loaderLogo ||
-                    this.editorConfig.customization.font && (this.editorConfig.customization.font.size || this.editorConfig.customization.font.name))) {
-                    Common.UI.warning({
-                        title: this.textPaidFeature,
-                        msg  : this.textCustomLoader,
-                        buttons: [{value: 'contact', caption: this.textContactUs}, {value: 'close', caption: this.textClose}],
-                        primary: 'contact',
-                        callback: function(btn) {
-                            if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
                     });
                 }
             },
@@ -1308,21 +1233,6 @@ define([
             },
 
             onEditorPermissions: function(params) {
-                var licType = params.asc_getLicenseType();
-                if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                    Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                    Common.UI.warning({
-                        title: Asc.c_oLicenseResult.NotBefore === licType ? this.titleLicenseNotActive : this.titleLicenseExp,
-                        msg: Asc.c_oLicenseResult.NotBefore === licType ? this.warnLicenseBefore : this.warnLicenseExp,
-                        buttons: [],
-                        closable: false
-                    });
-                    if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                        this.disableEditing(true);
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-                    return;
-                }
 
                 if ( this.onServerVersion(params.asc_getBuildVersion()) || !this.onLanguageLoaded() ) return;
                 if ( this._isDocReady || this._isPermissionsInited ) {
@@ -1333,10 +1243,8 @@ define([
                 if (params.asc_getRights() !== Asc.c_oRights.Edit)
                     this.permissions.edit = false;
 
-                this.appOptions.permissionsLicense = licType;
                 this.appOptions.isOffline      = this.api.asc_isOffline();
                 this.appOptions.isCrypted      = this.api.asc_isCrypto();
-                this.appOptions.canLicense     = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
                 this.appOptions.isLightVersion = params.asc_getIsLight();
                 /** coauthoring begin **/
                 this.appOptions.canCoAuthoring = !this.appOptions.isLightVersion;
@@ -1344,13 +1252,13 @@ define([
                 this.appOptions.canRequestEditRights = this.editorConfig.canRequestEditRights;
                 this.appOptions.canEdit        = this.permissions.edit !== false && // can edit
                                                  (this.editorConfig.canRequestEditRights || this.editorConfig.mode !== 'view'); // if mode=="view" -> canRequestEditRights must be defined
-                this.appOptions.isEdit         = this.appOptions.canLicense && this.appOptions.canEdit && this.editorConfig.mode !== 'view';
+                this.appOptions.isEdit         = this.appOptions.canEdit && this.editorConfig.mode !== 'view';
                 this.appOptions.canDownload    = this.permissions.download !== false;
                 this.appOptions.canAnalytics   = params.asc_getIsAnalyticsEnable();
-                this.appOptions.canComments    = this.appOptions.canLicense && (this.permissions.comment===undefined ? this.appOptions.isEdit : this.permissions.comment) && (this.editorConfig.mode !== 'view');
+                this.appOptions.canComments    = (this.permissions.comment===undefined ? this.appOptions.isEdit : this.permissions.comment) && (this.editorConfig.mode !== 'view');
                 this.appOptions.canComments    = this.appOptions.canComments && !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
                 this.appOptions.canViewComments = this.appOptions.canComments || !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
-                this.appOptions.canChat        = this.appOptions.canLicense && !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
+                this.appOptions.canChat        = !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
                                                                                                             (typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat===false);
                 if ((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat!==undefined) {
                     console.log("Obsolete: The 'chat' parameter of the 'customization' section is deprecated. Please use 'chat' parameter in the permissions instead.");
@@ -1384,7 +1292,7 @@ define([
                 this.appOptions.compactHeader = this.appOptions.customization && (typeof (this.appOptions.customization) == 'object') && !!this.appOptions.customization.compactHeader;
                 this.appOptions.twoLevelHeader = this.appOptions.isEdit; // when compactHeader=true some buttons move to toolbar
 
-                this.appOptions.canUseHistory  = this.appOptions.canLicense && this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
+                this.appOptions.canUseHistory  = this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
                 this.appOptions.canHistoryClose  = this.editorConfig.canHistoryClose;
                 this.appOptions.canHistoryRestore= this.editorConfig.canHistoryRestore;
 
@@ -1398,17 +1306,15 @@ define([
 
                 Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!
 
-                this.appOptions.canBranding  = params.asc_getCustomization();
-                if (this.appOptions.canBranding)
-                    appHeader.setBranding(this.editorConfig.customization, this.appOptions);
+                appHeader.setBranding(this.editorConfig.customization, this.appOptions);
 
                 this.appOptions.canFavorite = this.document.info && (this.document.info.favorite!==undefined && this.document.info.favorite!==null) && !this.appOptions.isOffline;
                 this.appOptions.canFavorite && appHeader.setFavorite(this.document.info.favorite);
 
-                this.appOptions.canUseReviewPermissions = this.appOptions.canLicense && (!!this.permissions.reviewGroups ||
-                                                         this.appOptions.canLicense && this.editorConfig.customization && this.editorConfig.customization.reviewPermissions && (typeof (this.editorConfig.customization.reviewPermissions) == 'object'));
-                this.appOptions.canUseCommentPermissions = this.appOptions.canLicense && !!this.permissions.commentGroups;
-                this.appOptions.canUseUserInfoPermissions = this.appOptions.canLicense && !!this.permissions.userInfoGroups;
+                this.appOptions.canUseReviewPermissions = (!!this.permissions.reviewGroups ||
+                                                         this.editorConfig.customization && this.editorConfig.customization.reviewPermissions && (typeof (this.editorConfig.customization.reviewPermissions) == 'object'));
+                this.appOptions.canUseCommentPermissions = !!this.permissions.commentGroups;
+                this.appOptions.canUseUserInfoPermissions = !!this.permissions.userInfoGroups;
                 AscCommon.UserInfoParser.setParser(true);
                 AscCommon.UserInfoParser.setCurrentName(this.appOptions.user.fullname);
                 this.appOptions.canUseReviewPermissions && AscCommon.UserInfoParser.setReviewPermissions(this.permissions.reviewGroups, this.editorConfig.customization.reviewPermissions);
@@ -1424,7 +1330,7 @@ define([
                 this.appOptions.user.image ? Common.UI.ExternalUsers.setImage(this.appOptions.user.id, this.appOptions.user.image) : Common.UI.ExternalUsers.get('info', this.appOptions.user.id);
 
                 // change = true by default in editor
-                this.appOptions.canLiveView = !!params.asc_getLiveViewerSupport() && (this.editorConfig.mode === 'view'); // viewer: change=false when no flag canLiveViewer (i.g. old license), change=true by default when canLiveViewer==true
+                this.appOptions.canLiveView = (this.editorConfig.mode === 'view');
                 this.appOptions.canChangeCoAuthoring = this.appOptions.isEdit && this.appOptions.canCoAuthoring && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false) ||
                                                        this.appOptions.canLiveView && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false);
                 this.appOptions.isAnonymousSupport = !!this.api.asc_isAnonymousSupport();

--- a/apps/presentationeditor/mobile/src/controller/Main.jsx
+++ b/apps/presentationeditor/mobile/src/controller/Main.jsx
@@ -586,7 +586,7 @@ class MainController extends Component {
         this.api.zoomFitToPage();
         this.api.asc_GetDefaultTableStyles && setTimeout(() => {this.api.asc_GetDefaultTableStyles()}, 1);
 
-        this.applyLicense();
+        this.applyRestrictions();
 
         Common.Gateway.documentReady();
         f7.emit('resize');
@@ -639,7 +639,7 @@ class MainController extends Component {
         }
     }
 
-    applyLicense () {
+    applyRestrictions () {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
 

--- a/apps/presentationeditor/mobile/src/controller/Main.jsx
+++ b/apps/presentationeditor/mobile/src/controller/Main.jsx
@@ -72,7 +72,6 @@ class MainController extends Component {
         });
 
         this._state = {
-            licenseType: false,
             isDocModified: false,
             requireUserAction: true
         };
@@ -185,7 +184,6 @@ class MainController extends Component {
                 }
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', onEditorPermissions);
-                this.api.asc_registerCallback('asc_onLicenseChanged', this.onLicenseChanged.bind(this));
                 this.api.asc_registerCallback('asc_onMacrosPermissionRequest', this.onMacrosPermissionRequest.bind(this));
                 this.api.asc_registerCallback('asc_onRunAutostartMacroses', this.onRunAutostartMacroses.bind(this));
                 this.api.asc_setDocInfo(docInfo);
@@ -205,36 +203,14 @@ class MainController extends Component {
             };
 
             const onEditorPermissions = params => {
-                const licType = params.asc_getLicenseType();
-                const { t } = this.props;
-                // const _t = t('Controller.Main', { returnObjects:true });
-               
-                if (Asc.c_oLicenseResult.Expired === licType ||
-                    Asc.c_oLicenseResult.Error === licType ||
-                    Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                    Asc.c_oLicenseResult.NotBefore === licType ||
-                    Asc.c_oLicenseResult.ExpiredLimited === licType) {
-
-                    f7.dialog.create({
-                        title: Asc.c_oLicenseResult.NotBefore === licType ? t('Controller.Main.titleLicenseNotActive') : t('Controller.Main.titleLicenseExp'),
-                        text: Asc.c_oLicenseResult.NotBefore === licType ? t('Controller.Main.warnLicenseBefore') : t('Controller.Main.warnLicenseExp')
-                    }).open();
-                    if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                        Common.Notifications.trigger('api:disconnect');
-                    }
-                    return;
-                }
-
                 if ( this.onServerVersion(params.asc_getBuildVersion()) ) return;
                 if ( this._isDocReady || this._isPermissionsInited ) {
                     this.api.asc_LoadDocument();
                     return;
                 }
 
-                this.appOptions.canLicense = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
-
                 const storeAppOptions = this.props.storeAppOptions;
-                storeAppOptions.setPermissionOptions(this.document, licType, params, this.permissions, EditorUIController.isSupportEditFeature());
+                storeAppOptions.setPermissionOptions(this.document, params, this.permissions, EditorUIController.isSupportEditFeature());
                 this.applyMode(storeAppOptions);
 
                 this._isPermissionsInited = true;
@@ -663,29 +639,9 @@ class MainController extends Component {
         }
     }
 
-    onLicenseChanged (params) {
-        const appOptions = this.props.storeAppOptions;
-        const licType = params.asc_getLicenseType();
-        if (licType !== undefined && (appOptions.canEdit || appOptions.isRestrictedEdit) && appOptions.config.mode !== 'view' &&
-            (licType === Asc.c_oLicenseResult.Connections || licType === Asc.c_oLicenseResult.UsersCount || licType === Asc.c_oLicenseResult.ConnectionsOS || licType === Asc.c_oLicenseResult.UsersCountOS
-                || licType === Asc.c_oLicenseResult.SuccessLimit && (appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-            this._state.licenseType = licType;
-
-        if (licType !== undefined && appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS||
-                                                                licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-            this._state.licenseType = licType;
-
-        if (this._isDocReady && this._state.licenseType)
-            this.applyLicense();
-    }
-
     applyLicense () {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
-
-        const warnNoLicense  = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
-        const warnNoLicenseUsers = _t.warnNoLicenseUsers.replace(/%1/g, __COMPANY_NAME__);
-        const textNoLicenseTitle = _t.textNoLicenseTitle.replace(/%1/g, __COMPANY_NAME__);
 
         const appOptions = this.props.storeAppOptions;
         if (appOptions.config.mode !== 'view' && !EditorUIController.isSupportEditFeature()) {
@@ -705,9 +661,7 @@ class MainController extends Component {
         }
 
         if (appOptions.config.mode === 'view') {
-            if (appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                            this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                                            !appOptions.isAnonymousSupport && !!appOptions.config.user.anonymous)) {
+            if (!appOptions.isAnonymousSupport && !!appOptions.config.user.anonymous) {
                 appOptions.canLiveView = false;
                 this.api.asc_SetFastCollaborative(false);
             }
@@ -722,64 +676,7 @@ class MainController extends Component {
                 text : _t.warnLicenseAnonymous,
                 buttons: [{ text: _t.textOk }]
             }).open();
-        } else if (this._state.licenseType) {
-            let license = this._state.licenseType;
-            let buttons = [{ text: _t.textOk }];
-            let title = textNoLicenseTitle;
-            if ((appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                (license === Asc.c_oLicenseResult.SuccessLimit ||
-                    appOptions.permissionsLicense === Asc.c_oLicenseResult.SuccessLimit)
-            ) {
-                license = _t.warnLicenseLimitedRenewed;
-            } else if (license === Asc.c_oLicenseResult.Connections || license === Asc.c_oLicenseResult.UsersCount) {
-                title = _t.titleReadOnly;
-                license = (license===Asc.c_oLicenseResult.Connections) ? _t.tipLicenseExceeded : _t.tipLicenseUsersExceeded;
-            } else {
-                license = (license === Asc.c_oLicenseResult.ConnectionsOS) ? warnNoLicense : warnNoLicenseUsers;
-                buttons = [{
-                    text: _t.textBuyNow,
-                    bold: true,
-                    onClick: function() {
-                        window.open(`${__PUBLISHER_URL__}`, "_blank");
-                    }
-                },
-                    {
-                        text: _t.textContactUs,
-                        onClick: function() {
-                            window.open(`mailto:${__SALES_EMAIL__}`, "_blank");
-                        }
-                    }];
-            }
-            if (this._state.licenseType === Asc.c_oLicenseResult.SuccessLimit) {
-                Common.Notifications.trigger('toolbar:activatecontrols');
-            } else {
-                Common.Notifications.trigger('toolbar:activatecontrols');
-                Common.Notifications.trigger('toolbar:deactivateeditcontrols');
-                this.api.asc_coAuthoringDisconnect();
-                Common.Notifications.trigger('api:disconnect');
-            }
-
-            f7.dialog.create({
-                title: title,
-                text : license,
-                buttons: buttons
-            }).open();
         } else {
-            if (!appOptions.isDesktopApp && !appOptions.canBrandingExt &&
-                appOptions.config && appOptions.config.customization && (appOptions.config.customization.loaderName || appOptions.config.customization.loaderLogo)) {
-                f7.dialog.create({
-                    title: _t.textPaidFeature,
-                    text  : _t.textCustomLoader,
-                    buttons: [{
-                        text: _t.textContactUs,
-                        bold: true,
-                        onClick: () => {
-                            window.open(`mailto:${__SALES_EMAIL__}`, "_blank");
-                        }
-                    },
-                        { text: _t.textClose }]
-                }).open();
-            }
             Common.Notifications.trigger('toolbar:activatecontrols');
         }
     }

--- a/apps/presentationeditor/mobile/src/page/main.jsx
+++ b/apps/presentationeditor/mobile/src/page/main.jsx
@@ -163,7 +163,7 @@ class MainPage extends Component {
 
         if(!appOptions.isDisconnected && appOptions.isDocReady) {
             const { logo } = customization;
-            isBranding = appOptions.canBranding || appOptions.canBrandingExt;
+            isBranding = appOptions.canBrandingExt;
             
             if(logo && isBranding) {
                 isHideLogo = logo.visible === false;

--- a/apps/presentationeditor/mobile/src/store/appOptions.js
+++ b/apps/presentationeditor/mobile/src/store/appOptions.js
@@ -15,7 +15,6 @@ export class storeAppOptions {
             lostEditingRights: observable,
             changeEditingRights: action,
             canBrandingExt: observable,
-            canBranding: observable,
 
             isDocReady: observable,
             changeDocReady: action,
@@ -29,7 +28,6 @@ export class storeAppOptions {
     isEdit = false;
     canViewComments = false;
     canBrandingExt = true;
-    canBranding = true;
     config = {};
     customization;
 
@@ -109,12 +107,11 @@ export class storeAppOptions {
         AscCommon.UserInfoParser.setCurrentName(this.user.fullname);
     }
 
-    setPermissionOptions (document, licType, params, permissions, isSupportEditFeature) {
+    setPermissionOptions (document, params, permissions, isSupportEditFeature) {
         if (params.asc_getRights() !== Asc.c_oRights.Edit)
             permissions.edit = false;
         this.review = (permissions.review === undefined) ? (permissions.edit !== false) : permissions.review;
         this.canAnalytics = params.asc_getIsAnalyticsEnable();
-        this.canLicense = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
         this.isLightVersion = params.asc_getIsLight();
         this.buildVersion = params.asc_getBuildVersion();
         this.canCoAuthoring = !this.isLightVersion;
@@ -123,16 +120,15 @@ export class storeAppOptions {
         this.canRequestEditRights = this.config.canRequestEditRights;
         this.canEdit = (permissions.edit !== false || permissions.review === true) && // can edit or review
             (this.config.canRequestEditRights || this.config.mode !== 'view') && // if mode=="view" -> canRequestEditRights must be defined
-            (!this.isReviewOnly || this.canLicense) && // if isReviewOnly==true -> canLicense must be true
             isSupportEditFeature;
-        this.isEdit = this.canLicense && this.canEdit && this.config.mode !== 'view';
-        this.canReview = this.canLicense && this.isEdit && (permissions.review===true);
-        this.canUseHistory = this.canLicense && this.config.canUseHistory && this.canCoAuthoring && !this.isDesktopApp && !this.isOffline;
+        this.isEdit = this.canEdit && this.config.mode !== 'view';
+        this.canReview = this.isEdit && (permissions.review===true);
+        this.canUseHistory = this.config.canUseHistory && this.canCoAuthoring && !this.isDesktopApp && !this.isOffline;
         this.canHistoryClose = this.config.canHistoryClose;
         this.canHistoryRestore= this.config.canHistoryRestore;
-        this.canUseMailMerge = this.canLicense && this.canEdit && !this.isDesktopApp;
-        this.canSendEmailAddresses = this.canLicense && this.config.canSendEmailAddresses && this.canEdit && this.canCoAuthoring;
-        this.canComments = this.canLicense && (permissions.comment === undefined ? this.isEdit : permissions.comment) && (this.config.mode !== 'view');
+        this.canUseMailMerge = this.canEdit && !this.isDesktopApp;
+        this.canSendEmailAddresses = this.config.canSendEmailAddresses && this.canEdit && this.canCoAuthoring;
+        this.canComments = (permissions.comment === undefined ? this.isEdit : permissions.comment) && (this.config.mode !== 'view');
         this.canComments = this.canComments && !((typeof (this.customization) == 'object') && this.customization.comments===false);
         this.canViewComments = this.canComments || !((typeof (this.customization) == 'object') && this.customization.comments===false);
         this.canEditComments = this.isOffline || !permissions.editCommentAuthorOnly;
@@ -143,28 +139,26 @@ export class storeAppOptions {
                 this.canEditComments = this.canDeleteComments = this.isOffline;
         }
         // this.isForm = !!window.isPDFForm;
-        this.canChat = this.canLicense && !this.isOffline && (permissions.chat !== false);
-        this.canEditStyles = this.canLicense && this.canEdit;
+        this.canChat = !this.isOffline && (permissions.chat !== false);
+        this.canEditStyles = this.canEdit;
         this.canPrint = (permissions.print !== false);
         this.isRestrictedEdit = !this.isEdit && this.canComments && isSupportEditFeature;
-        this.trialMode = params.asc_getLicenseMode();
 
         const type = /^(?:(pdf|djvu|xps|oxps))$/.exec(document.fileType);
         this.canDownloadOrigin = permissions.download !== false && (type && typeof type[1] === 'string');
         this.canDownload = permissions.download !== false && (!type || typeof type[1] !== 'string');
 
-        this.canBranding = params.asc_getCustomization();
         this.canBrandingExt = (typeof this.customization == 'object' || this.config.plugins);
 
-        this.canUseReviewPermissions = this.canLicense && (!!permissions.reviewGroups || this.customization
+        this.canUseReviewPermissions = (!!permissions.reviewGroups || this.customization
             && this.customization.reviewPermissions && (typeof (this.customization.reviewPermissions) == 'object'));
-        this.canUseCommentPermissions = this.canLicense && !!permissions.commentGroups;
-        this.canUseUserInfoPermissions = this.canLicense && !!permissions.userInfoGroups;
+        this.canUseCommentPermissions = !!permissions.commentGroups;
+        this.canUseUserInfoPermissions = !!permissions.userInfoGroups;
         this.canUseReviewPermissions && AscCommon.UserInfoParser.setReviewPermissions(permissions.reviewGroups, this.customization.reviewPermissions);
         this.canUseCommentPermissions && AscCommon.UserInfoParser.setCommentPermissions(permissions.commentGroups);
         this.canUseUserInfoPermissions && AscCommon.UserInfoParser.setUserInfoPermissions(permissions.userInfoGroups);
 
-        this.canLiveView = !!params.asc_getLiveViewerSupport() && (this.config.mode === 'view') && isSupportEditFeature;
+        this.canLiveView = (this.config.mode === 'view') && isSupportEditFeature;
         this.isAnonymousSupport = !!Common.EditorApi.get().asc_isAnonymousSupport();
         this.canCopy = permissions.copy !== false;
     }

--- a/apps/spreadsheeteditor/embed/js/ApplicationController.js
+++ b/apps/spreadsheeteditor/embed/js/ApplicationController.js
@@ -569,22 +569,7 @@ SSE.ApplicationController = new(function(){
     }
 
     function onEditorPermissions(params) {
-        var licType = params.asc_getLicenseType();
-        if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-            Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                common.controller.modals.showWarning({
-                    title: Asc.c_oLicenseResult.NotBefore === licType ? me.titleLicenseNotActive : me.titleLicenseExp,
-                    message: Asc.c_oLicenseResult.NotBefore === licType ? me.warnLicenseBefore : me.warnLicenseExp,
-                    buttons: []
-                });
-        
-                $('#dlg-warning').css('z-index', 20002).modal({backdrop: 'static', keyboard: false, show: true});
-                $('#dlg-warning button.close, #dlg-warning .modal-footer').remove();
-            return;
-        }
-
-        appOptions.canBranding  = params.asc_getCustomization();
-        appOptions.canBranding && setBranding(config.customization);
+        setBranding(config.customization);
 
         var $parent = labelDocName.parent();
         var _left_width = common.utils.getPosition($parent).left,
@@ -1022,10 +1007,6 @@ SSE.ApplicationController = new(function(){
         errorInconsistentExtPptx: 'An error has occurred while opening the file.<br>The file content corresponds to presentations (e.g. pptx), but the file has the inconsistent extension: %1.',
         errorInconsistentExtPdf: 'An error has occurred while opening the file.<br>The file content corresponds to one of the following formats: pdf/djvu/xps/oxps, but the file has the inconsistent extension: %1.',
         errorInconsistentExt: 'An error has occurred while opening the file.<br>The file content does not match the file extension.',
-        titleLicenseExp: 'License expired',
-        titleLicenseNotActive: 'License not active',
-        warnLicenseBefore: 'License not active. Please contact your administrator.',
-        warnLicenseExp: 'Your license has expired. Please update your license and refresh the page.',
         errorEditingDownloadas: 'An error occurred during the work with the document.<br>Use the \'Download as...\' option to save the file backup copy to your computer hard drive.',
         errorToken: 'The document security token is not correctly formed.<br>Please contact your Document Server administrator.',
         txtPressLink: 'Click the link to open it',

--- a/apps/spreadsheeteditor/main/app/controller/Main.js
+++ b/apps/spreadsheeteditor/main/app/controller/Main.js
@@ -176,7 +176,7 @@ define([
 //                $(document.body).css('position', 'absolute');
                 var me = this;
 
-                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, licenseType: false, isDocModified: false, requireUserAction: true};
+                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, isDocModified: false, requireUserAction: true};
 
                 if (!Common.Utils.isBrowserSupported()){
                     Common.Utils.showBrowserRestriction();
@@ -388,9 +388,6 @@ define([
                 });
 
                 me.defaultTitleText = '{{APP_TITLE_TEXT}}';
-                me.warnNoLicense  = (me.warnNoLicense || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.warnNoLicenseUsers = (me.warnNoLicenseUsers || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.textNoLicenseTitle = (me.textNoLicenseTitle || '').replace(/%1/g, '{{COMPANY_NAME}}');
                 Common.NotificationCenter.on('script:loaded', _.bind(me.onPostLoadComplete, me));
             },
 
@@ -612,7 +609,6 @@ define([
                 }
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', _.bind(this.onEditorPermissions, this));
-                this.api.asc_registerCallback('asc_onLicenseChanged',       _.bind(this.onLicenseChanged, this));
                 this.api.asc_registerCallback('asc_onMacrosPermissionRequest', _.bind(this.onMacrosPermissionRequest, this));
                 this.api.asc_registerCallback('asc_onRunAutostartMacroses', _.bind(this.onRunAutostartMacroses, this));
                 this.api.asc_setDocInfo(docInfo);
@@ -1073,7 +1069,7 @@ define([
 
                 leftMenuView.disableMenu('all',false);
 
-                if (!me.appOptions.isEditMailMerge && !me.appOptions.isEditDiagram && !me.appOptions.isEditOle && me.appOptions.canBranding) {
+                if (!me.appOptions.isEditMailMerge && !me.appOptions.isEditDiagram && !me.appOptions.isEditOle) {
                     me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
                 }
 
@@ -1210,28 +1206,9 @@ define([
                 }
             },
 
-            onLicenseChanged: function(params) {
-                if (this.appOptions.isEditDiagram || this.appOptions.isEditMailMerge || this.appOptions.isEditOle) return;
-
-                var licType = params.asc_getLicenseType();
-                if (licType !== undefined && (this.appOptions.canEdit || this.appOptions.isRestrictedEdit) && this.editorConfig.mode !== 'view' &&
-                    (licType===Asc.c_oLicenseResult.Connections || licType===Asc.c_oLicenseResult.UsersCount || licType===Asc.c_oLicenseResult.ConnectionsOS || licType===Asc.c_oLicenseResult.UsersCountOS
-                    || licType===Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-                    this._state.licenseType = licType;
-
-                if (licType !== undefined && this.appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS||
-                                                                             licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-                    this._state.licenseType = licType;
-
-                if (this._isDocReady)
-                    this.applyLicense();
-            },
-
             applyLicense: function() {
                 if (this.editorConfig.mode === 'view') {
-                    if (this.appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                                        this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                                                        !this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous)) {
+                    if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("sse-settings-coauthmode") was true ???
                         this.disableLiveViewing(true);
                     }
@@ -1243,59 +1220,6 @@ define([
                         title: this.notcriticalErrorTitle,
                         msg  : this.warnLicenseAnonymous,
                         buttons: ['ok']
-                    });
-                } else if (this._state.licenseType) {
-                    var license = this._state.licenseType,
-                        title = this.textNoLicenseTitle,
-                        buttons = ['ok'],
-                        primary = 'ok',
-                        modal = false;
-                    if ((this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                        (license===Asc.c_oLicenseResult.SuccessLimit || this.appOptions.permissionsLicense===Asc.c_oLicenseResult.SuccessLimit)) {
-                        license = this.warnLicenseLimitedRenewed;
-                    } else if (license===Asc.c_oLicenseResult.Connections || license===Asc.c_oLicenseResult.UsersCount) {
-                        title = this.titleReadOnly;
-                        license = (license===Asc.c_oLicenseResult.Connections) ? this.tipLicenseExceeded : this.tipLicenseUsersExceeded;
-                    } else {
-                        license = (license===Asc.c_oLicenseResult.ConnectionsOS) ? this.warnNoLicense : this.warnNoLicenseUsers;
-                        buttons = [{value: 'buynow', caption: this.textBuyNow}, {value: 'contact', caption: this.textContactUs}];
-                        primary = 'buynow';
-                        modal = true;
-                    }
-
-                    if (this._state.licenseType!==Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.isEdit || this.appOptions.isRestrictedEdit)) {
-                        this.disableEditing(true);
-                        this.api.asc_coAuthoringDisconnect();
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-
-                    !modal ? Common.UI.TooltipManager.showTip({ step: 'licenseError', text: license, header: title, target: '#toolbar', maxwidth: 430,
-                                                                automove: true, noHighlight: true, noArrow: true, textButton: this.textContinue}) :
-                    Common.UI.info({
-                        maxwidth: 500,
-                        title: title,
-                        msg  : license,
-                        buttons: buttons,
-                        primary: primary,
-                        callback: function(btn) {
-                            if (btn == 'buynow')
-                                window.open('{{PUBLISHER_URL}}', "_blank");
-                            else if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
-                    });
-                } else if (!this.appOptions.isDesktopApp && !this.appOptions.canBrandingExt && !(this.appOptions.isEditDiagram || this.appOptions.isEditMailMerge || this.appOptions.isEditOle) &&
-                    this.editorConfig && this.editorConfig.customization && (this.editorConfig.customization.loaderName || this.editorConfig.customization.loaderLogo ||
-                    this.editorConfig.customization.font && (this.editorConfig.customization.font.size || this.editorConfig.customization.font.name))) {
-                    Common.UI.warning({
-                        title: this.textPaidFeature,
-                        msg  : this.textCustomLoader,
-                        buttons: [{value: 'contact', caption: this.textContactUs}, {value: 'close', caption: this.textClose}],
-                        primary: 'contact',
-                        callback: function(btn) {
-                            if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
                     });
                 }
             },
@@ -1401,22 +1325,7 @@ define([
             },
 
             onEditorPermissions: function(params) {
-                var licType = params ? params.asc_getLicenseType() : Asc.c_oLicenseResult.Error;
                 if ( params && !(this.appOptions.isEditDiagram || this.appOptions.isEditMailMerge || this.appOptions.isEditOle)) {
-                    if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                        Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                        Common.UI.warning({
-                            title: Asc.c_oLicenseResult.NotBefore === licType ? this.titleLicenseNotActive : this.titleLicenseExp,
-                            msg: Asc.c_oLicenseResult.NotBefore === licType ? this.warnLicenseBefore : this.warnLicenseExp,
-                            buttons: [],
-                            closable: false
-                        });
-                        if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                            this.disableEditing(true);
-                            Common.NotificationCenter.trigger('api:disconnect');
-                        }
-                        return;
-                    }
 
                     if ( this.onServerVersion(params.asc_getBuildVersion()) || !this.onLanguageLoaded() ) return;
                     if ( this._isDocReady || this._isPermissionsInited ) {
@@ -1427,21 +1336,19 @@ define([
                     if (params.asc_getRights() !== Asc.c_oRights.Edit)
                         this.permissions.edit = false;
 
-                    this.appOptions.permissionsLicense = licType;
                     this.appOptions.canAutosave = true;
                     this.appOptions.canAnalytics = params.asc_getIsAnalyticsEnable();
 
                     this.appOptions.isOffline      = this.api.asc_isOffline();
                     this.appOptions.isCrypted      = this.api.asc_isCrypto();
-                    this.appOptions.canLicense     = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
                     this.appOptions.isLightVersion = params.asc_getIsLight();
                     /** coauthoring begin **/
                     this.appOptions.canCoAuthoring = !this.appOptions.isLightVersion;
                     /** coauthoring end **/
-                    this.appOptions.canComments    = this.appOptions.canLicense && (this.permissions.comment===undefined ? (this.permissions.edit !== false) : this.permissions.comment) && (this.editorConfig.mode !== 'view');
+                    this.appOptions.canComments    = (this.permissions.comment===undefined ? (this.permissions.edit !== false) : this.permissions.comment) && (this.editorConfig.mode !== 'view');
                     this.appOptions.canComments    = this.appOptions.canComments && !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
                     this.appOptions.canViewComments = this.appOptions.canComments || !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
-                    this.appOptions.canChat        = this.appOptions.canLicense && !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
+                    this.appOptions.canChat        = !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
                                                                                                                 (typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat===false);
                     if ((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat!==undefined) {
                         console.log("Obsolete: The 'chat' parameter of the 'customization' section is deprecated. Please use 'chat' parameter in the permissions instead.");
@@ -1457,18 +1364,16 @@ define([
                     this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                     Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!
 
-                    this.appOptions.canBranding  = params.asc_getCustomization();
-                    if (this.appOptions.canBranding)
-                        this.headerView.setBranding(this.editorConfig.customization, this.appOptions);
+                    this.headerView.setBranding(this.editorConfig.customization, this.appOptions);
 
                     this.appOptions.canFavorite = this.appOptions.spreadsheet.info && (this.appOptions.spreadsheet.info.favorite!==undefined && this.appOptions.spreadsheet.info.favorite!==null);
                     this.appOptions.canFavorite && this.headerView && this.headerView.setFavorite(this.appOptions.spreadsheet.info.favorite);
 
                     this.appOptions.canRename && this.headerView.setCanRename(true);
-                    this.appOptions.canUseReviewPermissions = this.appOptions.canLicense && (!!this.permissions.reviewGroups ||
-                                                            this.appOptions.canLicense && this.editorConfig.customization && this.editorConfig.customization.reviewPermissions && (typeof (this.editorConfig.customization.reviewPermissions) == 'object'));
-                    this.appOptions.canUseCommentPermissions = this.appOptions.canLicense && !!this.permissions.commentGroups;
-                    this.appOptions.canUseUserInfoPermissions = this.appOptions.canLicense && !!this.permissions.userInfoGroups;
+                    this.appOptions.canUseReviewPermissions = (!!this.permissions.reviewGroups ||
+                                                            this.editorConfig.customization && this.editorConfig.customization.reviewPermissions && (typeof (this.editorConfig.customization.reviewPermissions) == 'object'));
+                    this.appOptions.canUseCommentPermissions = !!this.permissions.commentGroups;
+                    this.appOptions.canUseUserInfoPermissions = !!this.permissions.userInfoGroups;
                     AscCommon.UserInfoParser.setParser(true);
                     AscCommon.UserInfoParser.setCurrentName(this.appOptions.user.fullname);
                     this.appOptions.canUseReviewPermissions && AscCommon.UserInfoParser.setReviewPermissions(this.permissions.reviewGroups, this.editorConfig.customization.reviewPermissions);
@@ -1483,7 +1388,7 @@ define([
                 this.appOptions.canRequestEditRights = this.editorConfig.canRequestEditRights;
                 this.appOptions.canEdit        = this.permissions.edit !== false && // can edit
                                                  (this.editorConfig.canRequestEditRights || this.editorConfig.mode !== 'view'); // if mode=="view" -> canRequestEditRights must be defined
-                this.appOptions.isEdit         = (this.appOptions.canLicense || this.appOptions.isEditDiagram || this.appOptions.isEditMailMerge || this.appOptions.isEditOle) && this.permissions.edit !== false && this.editorConfig.mode !== 'view';
+                this.appOptions.isEdit         = this.permissions.edit !== false && this.editorConfig.mode !== 'view';
                 this.appOptions.canDownload    = (this.permissions.download !== false);
                 this.appOptions.canPrint       = (this.permissions.print !== false) && !(this.appOptions.isEditDiagram || this.appOptions.isEditMailMerge || this.appOptions.isEditOle);
                 this.appOptions.canQuickPrint = this.appOptions.canPrint && !Common.Utils.isMac && this.appOptions.isDesktopApp;
@@ -1513,7 +1418,7 @@ define([
                 this.appOptions.twoLevelHeader = this.appOptions.isEdit; // when compactHeader=true some buttons move to toolbar
 
                 // change = true by default in editor
-                this.appOptions.canLiveView = !!params.asc_getLiveViewerSupport() && (this.editorConfig.mode === 'view'); // viewer: change=false when no flag canLiveViewer (i.g. old license), change=true by default when canLiveViewer==true
+                this.appOptions.canLiveView = (this.editorConfig.mode === 'view');
                 this.appOptions.canChangeCoAuthoring = this.appOptions.isEdit && !(this.appOptions.isEditDiagram || this.appOptions.isEditMailMerge || this.appOptions.isEditOle) && this.appOptions.canCoAuthoring &&
                                                        !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false) ||
                                                        this.appOptions.canLiveView && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false);
@@ -1525,7 +1430,7 @@ define([
                     this.appOptions.user.image ? Common.UI.ExternalUsers.setImage(this.appOptions.user.id, this.appOptions.user.image) : Common.UI.ExternalUsers.get('info', this.appOptions.user.id);
                 }
 
-                this.appOptions.canUseHistory  = this.appOptions.canLicense && this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
+                this.appOptions.canUseHistory  = this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
                 this.appOptions.canHistoryClose  = this.editorConfig.canHistoryClose;
                 this.appOptions.canHistoryRestore= this.editorConfig.canHistoryRestore;
 

--- a/apps/spreadsheeteditor/main/app/controller/Main.js
+++ b/apps/spreadsheeteditor/main/app/controller/Main.js
@@ -1144,7 +1144,7 @@ define([
                                 toolbarController.onApiCoAuthoringDisconnect();
 
                             Common.NotificationCenter.trigger('document:ready', 'main');
-                            me.applyLicense();
+                            me.applyRestrictions();
                         }
                     }, 50);
                 } else {
@@ -1153,7 +1153,7 @@ define([
                     documentHolderView.createDelayedElementsViewer();
                     Common.Utils.injectSvgIcons();
                     Common.NotificationCenter.trigger('document:ready', 'main');
-                    me.applyLicense();
+                    me.applyRestrictions();
                 }
                 // TODO bug 43960
                 if (!me.appOptions.isEditMailMerge && !me.appOptions.isEditDiagram && !me.appOptions.isEditOle) {
@@ -1206,7 +1206,7 @@ define([
                 }
             },
 
-            applyLicense: function() {
+            applyRestrictions: function() {
                 if (this.editorConfig.mode === 'view') {
                     if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("sse-settings-coauthmode") was true ???

--- a/apps/spreadsheeteditor/mobile/src/controller/Main.jsx
+++ b/apps/spreadsheeteditor/mobile/src/controller/Main.jsx
@@ -744,7 +744,7 @@ class MainController extends Component {
             mode: appOptions.isEdit ? 'edit' : 'view'
         });
 
-        this.applyLicense();
+        this.applyRestrictions();
 
         //R1C1 reference style
         value = LocalStorage.getBool('sse-settings-r1c1', false);
@@ -818,7 +818,7 @@ class MainController extends Component {
         window.onunload = this.onUnload.bind(this);
     }
 
-    applyLicense () {
+    applyRestrictions () {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
 

--- a/apps/spreadsheeteditor/mobile/src/controller/Main.jsx
+++ b/apps/spreadsheeteditor/mobile/src/controller/Main.jsx
@@ -142,7 +142,6 @@ class MainController extends Component {
         });
 
         this._state = {
-            licenseType: false,
             isDocModified: false,
             requireUserAction: true
         };
@@ -286,7 +285,6 @@ class MainController extends Component {
                 }
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', onEditorPermissions);
-                this.api.asc_registerCallback('asc_onLicenseChanged',       this.onLicenseChanged.bind(this));
                 this.api.asc_registerCallback('asc_onMacrosPermissionRequest', this.onMacrosPermissionRequest.bind(this));
                 this.api.asc_registerCallback('asc_onRunAutostartMacroses', this.onRunAutostartMacroses.bind(this));
                 this.api.asc_setDocInfo(docInfo);
@@ -303,36 +301,14 @@ class MainController extends Component {
             };
 
             const onEditorPermissions = params => {
-                const licType = params.asc_getLicenseType();
-                const { t } = this.props;
-                // const _t = t('Controller.Main', { returnObjects:true });
-               
-                if (Asc.c_oLicenseResult.Expired === licType ||
-                    Asc.c_oLicenseResult.Error === licType ||
-                    Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                    Asc.c_oLicenseResult.NotBefore === licType ||
-                    Asc.c_oLicenseResult.ExpiredLimited === licType) {
-
-                    f7.dialog.create({
-                        title: Asc.c_oLicenseResult.NotBefore === licType ? t('Controller.Main.titleLicenseNotActive') : t('Controller.Main.titleLicenseExp'),
-                        text: Asc.c_oLicenseResult.NotBefore === licType ? t('Controller.Main.warnLicenseBefore') : t('Controller.Main.warnLicenseExp')
-                    }).open();
-                    if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                        Common.Notifications.trigger('api:disconnect');
-                    }
-                    return;
-                }
-
                 if ( this.onServerVersion(params.asc_getBuildVersion()) ) return;
                 if ( this._isDocReady || this._isPermissionsInited ) {
                     this.api.asc_LoadDocument();
                     return;
                 }
 
-                this.appOptions.canLicense = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
-
                 const appOptions = this.props.storeAppOptions;
-                appOptions.setPermissionOptions(this.document, licType, params, this.permissions, EditorUIController.isSupportEditFeature());
+                appOptions.setPermissionOptions(this.document, params, this.permissions, EditorUIController.isSupportEditFeature());
 
                 this.applyMode(appOptions);
 
@@ -842,31 +818,9 @@ class MainController extends Component {
         window.onunload = this.onUnload.bind(this);
     }
 
-    onLicenseChanged (params) {
-        const appOptions = this.props.storeAppOptions;
-        if (appOptions.isEditDiagram || appOptions.isEditMailMerge) return;
-
-        const licType = params.asc_getLicenseType();
-        if (licType !== undefined && (appOptions.canEdit || appOptions.isRestrictedEdit) && appOptions.config.mode !== 'view' &&
-            (licType === Asc.c_oLicenseResult.Connections || licType === Asc.c_oLicenseResult.UsersCount || licType === Asc.c_oLicenseResult.ConnectionsOS || licType === Asc.c_oLicenseResult.UsersCountOS
-                || licType === Asc.c_oLicenseResult.SuccessLimit && (appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-            this._state.licenseType = licType;
-
-        if (licType !== undefined && appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS||
-                                                                licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-            this._state.licenseType = licType;
-
-        if (this._isDocReady && this._state.licenseType)
-            this.applyLicense();
-    }
-
     applyLicense () {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
-
-        const warnNoLicense = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
-        const warnNoLicenseUsers = _t.warnNoLicenseUsers.replace(/%1/g, __COMPANY_NAME__);
-        const textNoLicenseTitle = _t.textNoLicenseTitle.replace(/%1/g, __COMPANY_NAME__);
 
         const appOptions = this.props.storeAppOptions;
         if (appOptions.config.mode !== 'view' && !EditorUIController.isSupportEditFeature()) {
@@ -886,9 +840,7 @@ class MainController extends Component {
         }
 
         if (appOptions.config.mode === 'view') {
-            if (appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                            this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                                            !appOptions.isAnonymousSupport && !!appOptions.config.user.anonymous)) {
+            if (!appOptions.isAnonymousSupport && !!appOptions.config.user.anonymous) {
                 appOptions.canLiveView = false;
                 this.api.asc_SetFastCollaborative(false);
             }
@@ -903,64 +855,7 @@ class MainController extends Component {
                 text : _t.warnLicenseAnonymous,
                 buttons: [{ text: _t.textOk }]
             }).open();
-        } else if (this._state.licenseType) {
-            let license = this._state.licenseType;
-            let buttons = [{ text: _t.textOk }];
-            let title = textNoLicenseTitle;
-            if ((appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                (license === Asc.c_oLicenseResult.SuccessLimit ||
-                    appOptions.permissionsLicense === Asc.c_oLicenseResult.SuccessLimit)
-            ) {
-                license = _t.warnLicenseLimitedRenewed;
-            } else if (license === Asc.c_oLicenseResult.Connections || license === Asc.c_oLicenseResult.UsersCount) {
-                title = _t.titleReadOnly;
-                license = (license===Asc.c_oLicenseResult.Connections) ? _t.tipLicenseExceeded : _t.tipLicenseUsersExceeded;
-            } else {
-                license = (license === Asc.c_oLicenseResult.ConnectionsOS) ? warnNoLicense : warnNoLicenseUsers;
-                buttons = [{
-                    text: _t.textBuyNow,
-                    bold: true,
-                    onClick: function() {
-                        window.open(`${__PUBLISHER_URL__}`, "_blank");
-                    }
-                },
-                    {
-                        text: _t.textContactUs,
-                        onClick: function() {
-                            window.open(`mailto:${__SALES_EMAIL__}`, "_blank");
-                        }
-                    }];
-            }
-            if (this._state.licenseType === Asc.c_oLicenseResult.SuccessLimit) {
-                Common.Notifications.trigger('toolbar:activatecontrols');
-            } else {
-                Common.Notifications.trigger('toolbar:activatecontrols');
-                Common.Notifications.trigger('toolbar:deactivateeditcontrols');
-                this.api.asc_coAuthoringDisconnect();
-                Common.Notifications.trigger('api:disconnect');
-            }
-
-            f7.dialog.create({
-                title: title,
-                text : license,
-                buttons: buttons
-            }).open();
         } else {
-            if (!appOptions.isDesktopApp && !appOptions.canBrandingExt &&
-                appOptions.config && appOptions.config.customization && (appOptions.config.customization.loaderName || appOptions.config.customization.loaderLogo)) {
-                f7.dialog.create({
-                    title: _t.textPaidFeature,
-                    text  : _t.textCustomLoader,
-                    buttons: [{
-                        text: _t.textContactUs,
-                        bold: true,
-                        onClick: () => {
-                            window.open(`mailto:${__SALES_EMAIL__}`, "_blank");
-                        }
-                    },
-                        { text: _t.textClose }]
-                }).open();
-            }
             Common.Notifications.trigger('toolbar:activatecontrols');
         }
     }

--- a/apps/spreadsheeteditor/mobile/src/page/main.jsx
+++ b/apps/spreadsheeteditor/mobile/src/page/main.jsx
@@ -157,7 +157,7 @@ class MainPage extends Component {
 
         if(!appOptions.isDisconnected && appOptions.isDocReady) {
             const { logo } = customization;
-            isBranding = appOptions.canBranding || appOptions.canBrandingExt;
+            isBranding = appOptions.canBrandingExt;
             
             if(logo && isBranding) {
                 isHideLogo = logo.visible === false;

--- a/apps/spreadsheeteditor/mobile/src/store/appOptions.js
+++ b/apps/spreadsheeteditor/mobile/src/store/appOptions.js
@@ -15,7 +15,6 @@ export class storeAppOptions {
             lostEditingRights: observable,
             changeEditingRights: action,
 
-            canBranding: observable,
             canBrandingExt: observable,
 
             isDocReady: observable,
@@ -41,7 +40,6 @@ export class storeAppOptions {
         this.canViewComments = value;
     }
 
-    canBranding = true;
     canBrandingExt = true;
 
     lostEditingRights = false;
@@ -117,15 +115,13 @@ export class storeAppOptions {
         AscCommon.UserInfoParser.setCurrentName(this.user.fullname);
     }
 
-    setPermissionOptions (document, licType, params, permissions, isSupportEditFeature) {
+    setPermissionOptions (document, params, permissions, isSupportEditFeature) {
         if (params.asc_getRights() !== Asc.c_oRights.Edit)
             permissions.edit = false;
-        this.canBranding = params.asc_getCustomization();
         this.canBrandingExt = (typeof this.customization == 'object' || this.config.plugins);
         this.canModifyFilter = permissions.modifyFilter !== false;
         this.canAutosave = true;
         this.canAnalytics = params.asc_getIsAnalyticsEnable();
-        this.canLicense = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
         this.isLightVersion = params.asc_getIsLight();
         this.buildVersion = params.asc_getBuildVersion();
         this.canCoAuthoring = !this.isLightVersion;
@@ -133,9 +129,8 @@ export class storeAppOptions {
         this.canRequestEditRights = this.config.canRequestEditRights;
         this.canEdit = permissions.edit !== false  && // can edit or review
             (this.config.canRequestEditRights || this.config.mode !== 'view') && isSupportEditFeature; // if mode=="view" -> canRequestEditRights must be defined
-            // (!this.isReviewOnly || this.canLicense) && // if isReviewOnly==true -> canLicense must be true
-        this.isEdit = (this.canLicense || this.isEditDiagram || this.isEditMailMerge) && permissions.edit !== false && this.config.mode !== 'view' && isSupportEditFeature;
-        this.canComments = this.canLicense && (permissions.comment === undefined ? this.isEdit : permissions.comment) && (this.config.mode !== 'view');
+        this.isEdit = permissions.edit !== false && this.config.mode !== 'view' && isSupportEditFeature;
+        this.canComments = (permissions.comment === undefined ? this.isEdit : permissions.comment) && (this.config.mode !== 'view');
         this.canComments = this.canComments && !((typeof (this.customization) == 'object') && this.customization.comments===false);
         this.canViewComments = this.canComments || !((typeof (this.customization) == 'object') && this.customization.comments===false);
         this.canEditComments = this.isOffline || !permissions.editCommentAuthorOnly;
@@ -146,27 +141,26 @@ export class storeAppOptions {
                 this.canEditComments = this.canDeleteComments = this.isOffline;
         }
         // this.isForm = !!window.isPDFForm;
-        this.canChat = this.canLicense && !this.isOffline && (permissions.chat !== false);
+        this.canChat = !this.isOffline && (permissions.chat !== false);
         this.canPrint = (permissions.print !== false);
         this.isRestrictedEdit = !this.isEdit && this.canComments && isSupportEditFeature;
-        this.trialMode = params.asc_getLicenseMode();
 
         const type = /^(?:(pdf|djvu|xps|oxps))$/.exec(document.fileType);
         this.canDownloadOrigin = permissions.download !== false && (type && typeof type[1] === 'string');
         this.canDownload = permissions.download !== false && (!type || typeof type[1] !== 'string');
-        this.canUseReviewPermissions = this.canLicense && (!!permissions.reviewGroups || this.customization
+        this.canUseReviewPermissions = (!!permissions.reviewGroups || this.customization
             && this.customization.reviewPermissions && (typeof (this.customization.reviewPermissions) == 'object'));
-        this.canUseCommentPermissions = this.canLicense && !!permissions.commentGroups;
-        this.canUseUserInfoPermissions = this.canLicense && !!permissions.userInfoGroups;
+        this.canUseCommentPermissions = !!permissions.commentGroups;
+        this.canUseUserInfoPermissions = !!permissions.userInfoGroups;
         this.canUseReviewPermissions && AscCommon.UserInfoParser.setReviewPermissions(permissions.reviewGroups, this.customization.reviewPermissions);
         this.canUseCommentPermissions && AscCommon.UserInfoParser.setCommentPermissions(permissions.commentGroups);
         this.canUseUserInfoPermissions && AscCommon.UserInfoParser.setUserInfoPermissions(permissions.userInfoGroups);
 
-        this.canUseHistory = this.canLicense && this.config.canUseHistory && this.canCoAuthoring && !this.isDesktopApp && !this.isOffline;
+        this.canUseHistory = this.config.canUseHistory && this.canCoAuthoring && !this.isDesktopApp && !this.isOffline;
         this.canHistoryClose = this.config.canHistoryClose;
         this.canHistoryRestore= this.config.canHistoryRestore;
 
-        this.canLiveView = !!params.asc_getLiveViewerSupport() && (this.config.mode === 'view') && isSupportEditFeature;
+        this.canLiveView = (this.config.mode === 'view') && isSupportEditFeature;
         this.isAnonymousSupport = !!Common.EditorApi.get().asc_isAnonymousSupport();
         this.canCopy = permissions.copy !== false;
     }

--- a/apps/visioeditor/embed/js/ApplicationController.js
+++ b/apps/visioeditor/embed/js/ApplicationController.js
@@ -597,22 +597,7 @@ VE.ApplicationController = new(function(){
     }
 
     function onEditorPermissions(params) {
-        var licType = params.asc_getLicenseType();
-        if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-            Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                common.controller.modals.showWarning({
-                    title: Asc.c_oLicenseResult.NotBefore === licType ? me.titleLicenseNotActive : me.titleLicenseExp,
-                    message: Asc.c_oLicenseResult.NotBefore === licType ? me.warnLicenseBefore : me.warnLicenseExp,
-                    buttons: []
-                });
-        
-                $('#dlg-warning').css('z-index', 20002);
-                $('#dlg-warning button.close, #dlg-warning .modal-footer').remove();;
-            return;
-        }
-
-        appOptions.canBranding  = params.asc_getCustomization();
-        appOptions.canBranding && setBranding(config.customization);
+        setBranding(config.customization);
 
         var $parent = labelDocName.parent();
         var _left_width = common.utils.getPosition($parent).left,
@@ -962,10 +947,6 @@ VE.ApplicationController = new(function(){
         errorInconsistentExtPptx: 'An error has occurred while opening the file.<br>The file content corresponds to presentations (e.g. pptx), but the file has the inconsistent extension: %1.',
         errorInconsistentExtPdf: 'An error has occurred while opening the file.<br>The file content corresponds to one of the following formats: pdf/djvu/xps/oxps, but the file has the inconsistent extension: %1.',
         errorInconsistentExt: 'An error has occurred while opening the file.<br>The file content does not match the file extension.',
-        titleLicenseExp: 'License expired',
-        titleLicenseNotActive: 'License not active',
-        warnLicenseBefore: 'License not active. Please contact your administrator.',
-        warnLicenseExp: 'Your license has expired. Please update your license and refresh the page.',
         errorEditingDownloadas: 'An error occurred during the work with the document.<br>Use the \'Download as...\' option to save the file backup copy to your computer hard drive.',
         errorToken: 'The document security token is not correctly formed.<br>Please contact your Document Server administrator.',
         txtPressLink: 'Click the link to open it',

--- a/apps/visioeditor/main/app/controller/Main.js
+++ b/apps/visioeditor/main/app/controller/Main.js
@@ -101,7 +101,7 @@ define([
 
                 this.stackMacrosRequests = [];
 
-                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, licenseType: false, isDocModified: false, requireUserAction: true};
+                this._state = {isDisconnected: false, usersCount: 1, fastCoauth: true, lostEditingRights: false, isDocModified: false, requireUserAction: true};
                 this.languages = null;
 
                 // Initialize viewport
@@ -292,9 +292,6 @@ define([
                 }
 
                 me.defaultTitleText = '{{APP_TITLE_TEXT}}';
-                me.warnNoLicense  = (me.warnNoLicense || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.warnNoLicenseUsers = (me.warnNoLicenseUsers || '').replace(/%1/g, '{{COMPANY_NAME}}');
-                me.textNoLicenseTitle = (me.textNoLicenseTitle || '').replace(/%1/g, '{{COMPANY_NAME}}');
             },
 
             loadConfig: function(data) {
@@ -455,7 +452,6 @@ define([
                 }
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', _.bind(this.onEditorPermissions, this));
-                this.api.asc_registerCallback('asc_onLicenseChanged',       _.bind(this.onLicenseChanged, this));
                 // this.api.asc_registerCallback('asc_onRunAutostartMacroses', _.bind(this.onRunAutostartMacroses, this));
                 this.api.asc_setDocInfo(docInfo);
                 this.api.asc_getEditorPermissions(this.editorConfig.licenseUrl, this.editorConfig.customerId);
@@ -942,8 +938,7 @@ define([
 
                 leftmenuController.getView('LeftMenu').disableMenu('all',false);
 
-                if (me.appOptions.canBranding)
-                    me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
+                me.getApplication().getController('LeftMenu').leftMenu.getMenu('about').setLicInfo(me.editorConfig.customization);
 
                 documentHolderController.getView().on('editcomplete', _.bind(me.onEditComplete, me));
 
@@ -1011,26 +1006,9 @@ define([
                     this.getApplication().getController('LeftMenu').leftMenu.showMenu('file:saveas');
             },
 
-            onLicenseChanged: function(params) {
-                var licType = params.asc_getLicenseType();
-                if (licType !== undefined && (this.appOptions.canEdit || this.appOptions.isRestrictedEdit) && this.editorConfig.mode !== 'view' &&
-                    (licType===Asc.c_oLicenseResult.Connections || licType===Asc.c_oLicenseResult.UsersCount || licType===Asc.c_oLicenseResult.ConnectionsOS || licType===Asc.c_oLicenseResult.UsersCountOS
-                    || licType===Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-                    this._state.licenseType = licType;
-
-                if (licType !== undefined && this.appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS||
-                    licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-                    this._state.licenseType = licType;
-
-                if (this._isDocReady)
-                    this.applyLicense();
-            },
-
             applyLicense: function() {
                 if (this.editorConfig.mode === 'view') {
-                    if (this.appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                                        this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                                                        !this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous)) {
+                    if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("de-settings-coauthmode") was true ???
                         this.disableLiveViewing(true);
                     }
@@ -1043,57 +1021,6 @@ define([
                         msg  : this.warnLicenseAnonymous,
                         buttons: ['ok']
                     });
-                } else if (this._state.licenseType) {
-                    var license = this._state.licenseType,
-                        title = this.textNoLicenseTitle,
-                        buttons = ['ok'],
-                        primary = 'ok',
-                        modal = false;
-                    if ((this.appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                        (license===Asc.c_oLicenseResult.SuccessLimit || this.appOptions.permissionsLicense===Asc.c_oLicenseResult.SuccessLimit)) {
-                        license = this.warnLicenseLimitedRenewed;
-                    } else if (license===Asc.c_oLicenseResult.Connections || license===Asc.c_oLicenseResult.UsersCount) {
-                        title = this.titleReadOnly;
-                        license = (license===Asc.c_oLicenseResult.Connections) ? this.tipLicenseExceeded : this.tipLicenseUsersExceeded;
-                    } else {
-                        license = (license===Asc.c_oLicenseResult.ConnectionsOS) ? this.warnNoLicense : this.warnNoLicenseUsers;
-                        buttons = [{value: 'buynow', caption: this.textBuyNow}, {value: 'contact', caption: this.textContactUs}];
-                        primary = 'buynow';
-                        modal = true;
-                    }
-
-                    if (this._state.licenseType!==Asc.c_oLicenseResult.SuccessLimit && (this.appOptions.isEdit || this.appOptions.isRestrictedEdit)) {
-                        this.disableEditing(true);
-                        this.api.asc_coAuthoringDisconnect();
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-
-                    Common.UI.info({
-                        maxwidth: 500,
-                        title: title,
-                        msg  : license,
-                        buttons: buttons,
-                        primary: primary,
-                        callback: function(btn) {
-                            if (btn == 'buynow')
-                                window.open('{{PUBLISHER_URL}}', "_blank");
-                            else if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
-                    });
-                } else if (!this.appOptions.isDesktopApp && !this.appOptions.canBrandingExt &&
-                    this.editorConfig && this.editorConfig.customization && (this.editorConfig.customization.loaderName || this.editorConfig.customization.loaderLogo ||
-                        this.editorConfig.customization.font && (this.editorConfig.customization.font.size || this.editorConfig.customization.font.name))) {
-                    Common.UI.warning({
-                        title: this.textPaidFeature,
-                        msg  : this.textCustomLoader,
-                        buttons: [{value: 'contact', caption: this.textContactUs}, {value: 'close', caption: this.textClose}],
-                        primary: 'contact',
-                        callback: function(btn) {
-                            if (btn == 'contact')
-                                window.open('mailto:{{SALES_EMAIL}}', "_blank");
-                        }
-                    });
                 }
             },
 
@@ -1105,21 +1032,6 @@ define([
             },
 
             onEditorPermissions: function(params) {
-                var licType = params.asc_getLicenseType();
-                if (Asc.c_oLicenseResult.Expired === licType || Asc.c_oLicenseResult.Error === licType || Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                    Asc.c_oLicenseResult.NotBefore === licType || Asc.c_oLicenseResult.ExpiredLimited === licType) {
-                    Common.UI.warning({
-                        title: Asc.c_oLicenseResult.NotBefore === licType ? this.titleLicenseNotActive : this.titleLicenseExp,
-                        msg: Asc.c_oLicenseResult.NotBefore === licType ? this.warnLicenseBefore : this.warnLicenseExp,
-                        buttons: [],
-                        closable: false
-                    });
-                    if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                        this.disableEditing(true);
-                        Common.NotificationCenter.trigger('api:disconnect');
-                    }
-                    return;
-                }
 
                 if ( this.onServerVersion(params.asc_getBuildVersion()) || !this.onLanguageLoaded()) return;
                 if ( this._isDocReady || this._isPermissionsInited ) {
@@ -1130,10 +1042,8 @@ define([
                 if (params.asc_getRights() !== Asc.c_oRights.Edit)
                     this.permissions.edit = this.permissions.review = false;
 
-                this.appOptions.permissionsLicense = licType;
                 this.appOptions.isOffline      = this.api.asc_isOffline();
                 this.appOptions.isCrypted      = this.api.asc_isCrypto();
-                this.appOptions.canLicense     = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
                 this.appOptions.isLightVersion = params.asc_getIsLight();
                 /** coauthoring begin **/
                 this.appOptions.canCoAuthoring = !this.appOptions.isLightVersion;
@@ -1141,13 +1051,13 @@ define([
                 this.appOptions.canRequestEditRights = this.editorConfig.canRequestEditRights;
                 this.appOptions.canEdit        = false;//this.permissions.edit !== false && // can edit
                                                 // (this.editorConfig.canRequestEditRights || this.editorConfig.mode !== 'view'); // if mode=="view" -> canRequestEditRights must be defined
-                this.appOptions.isEdit         = this.appOptions.canLicense && this.appOptions.canEdit && this.editorConfig.mode !== 'view';
+                this.appOptions.isEdit         = this.appOptions.canEdit && this.editorConfig.mode !== 'view';
                 this.appOptions.canDownload    = this.permissions.download !== false;
                 this.appOptions.canAnalytics   = params.asc_getIsAnalyticsEnable();
-                this.appOptions.canComments    = false;//this.appOptions.canLicense && (this.permissions.comment===undefined ? this.appOptions.isEdit : this.permissions.comment) && (this.editorConfig.mode !== 'view');
+                this.appOptions.canComments    = false;//(this.permissions.comment===undefined ? this.appOptions.isEdit : this.permissions.comment) && (this.editorConfig.mode !== 'view');
                 this.appOptions.canComments    = false;//this.appOptions.canComments && !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
                 this.appOptions.canViewComments = false;//this.appOptions.canComments || !((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.comments===false);
-                this.appOptions.canChat        = this.appOptions.canLicense && !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
+                this.appOptions.canChat        = !this.appOptions.isOffline && !(this.permissions.chat===false || (this.permissions.chat===undefined) &&
                                                 (typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat===false);
                 if ((typeof (this.editorConfig.customization) == 'object') && this.editorConfig.customization.chat!==undefined) {
                     console.log("Obsolete: The 'chat' parameter of the 'customization' section is deprecated. Please use 'chat' parameter in the permissions instead.");
@@ -1181,7 +1091,7 @@ define([
                 this.appOptions.compactHeader = this.appOptions.customization && (typeof (this.appOptions.customization) == 'object') && !!this.appOptions.customization.compactHeader;
                 this.appOptions.twoLevelHeader = this.appOptions.isEdit; // when compactHeader=true some buttons move to toolbar
 
-                this.appOptions.canUseHistory  = false;//this.appOptions.canLicense && this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
+                this.appOptions.canUseHistory  = false;//this.editorConfig.canUseHistory && this.appOptions.canCoAuthoring && !this.appOptions.isOffline;
                 this.appOptions.canHistoryClose  = this.editorConfig.canHistoryClose;
                 this.appOptions.canHistoryRestore= this.editorConfig.canHistoryRestore;
 
@@ -1194,15 +1104,13 @@ define([
                 this.editorConfig.customization && Common.UI.FeaturesManager.init(this.editorConfig.customization.features, this.appOptions.canBrandingExt);
                 Common.UI.TabStyler.init(this.editorConfig.customization); // call after Common.UI.FeaturesManager.init() !!!
 
-                this.appOptions.canBranding  = params.asc_getCustomization();
-                if (this.appOptions.canBranding)
-                    appHeader.setBranding(this.editorConfig.customization, this.appOptions);
+                appHeader.setBranding(this.editorConfig.customization, this.appOptions);
 
                 this.appOptions.canFavorite = this.document.info && (this.document.info.favorite!==undefined && this.document.info.favorite!==null) && !this.appOptions.isOffline;
                 this.appOptions.canFavorite && appHeader.setFavorite(this.document.info.favorite);
 
-                this.appOptions.canUseCommentPermissions = this.appOptions.canLicense && !!this.permissions.commentGroups;
-                this.appOptions.canUseUserInfoPermissions = this.appOptions.canLicense && !!this.permissions.userInfoGroups;
+                this.appOptions.canUseCommentPermissions = !!this.permissions.commentGroups;
+                this.appOptions.canUseUserInfoPermissions = !!this.permissions.userInfoGroups;
                 AscCommon.UserInfoParser.setParser(true);
                 AscCommon.UserInfoParser.setCurrentName(this.appOptions.user.fullname);
                 this.appOptions.canUseCommentPermissions && AscCommon.UserInfoParser.setCommentPermissions(this.permissions.commentGroups);
@@ -1217,7 +1125,7 @@ define([
                 this.appOptions.user.image ? Common.UI.ExternalUsers.setImage(this.appOptions.user.id, this.appOptions.user.image) : Common.UI.ExternalUsers.get('info', this.appOptions.user.id);
 
                 // change = true by default in editor
-                this.appOptions.canLiveView = !!params.asc_getLiveViewerSupport() && (this.editorConfig.mode === 'view'); // viewer: change=false when no flag canLiveViewer (i.g. old license), change=true by default when canLiveViewer==true
+                this.appOptions.canLiveView = (this.editorConfig.mode === 'view');
                 this.appOptions.canChangeCoAuthoring = this.appOptions.isEdit && this.appOptions.canCoAuthoring && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false) ||
                     this.appOptions.canLiveView && !(this.editorConfig.coEditing && typeof this.editorConfig.coEditing == 'object' && this.editorConfig.coEditing.change===false);
                 this.appOptions.isAnonymousSupport = !!this.api.asc_isAnonymousSupport();

--- a/apps/visioeditor/main/app/controller/Main.js
+++ b/apps/visioeditor/main/app/controller/Main.js
@@ -959,12 +959,12 @@ define([
                         me.api.UpdateInterfaceState();
 
                         Common.NotificationCenter.trigger('document:ready', 'main');
-                        me.applyLicense();
+                        me.applyRestrictions();
                     }, 500);
                 } else {
                     Common.NotificationCenter.trigger('document:ready', 'main');
                     Common.Utils.injectSvgIcons();
-                    me.applyLicense();
+                    me.applyRestrictions();
                 }
 
                 // TODO bug 43960
@@ -1006,7 +1006,7 @@ define([
                     this.getApplication().getController('LeftMenu').leftMenu.showMenu('file:saveas');
             },
 
-            applyLicense: function() {
+            applyRestrictions: function() {
                 if (this.editorConfig.mode === 'view') {
                     if (!this.appOptions.isAnonymousSupport && !!this.appOptions.user.anonymous) {
                         // show warning or write to log if Common.Utils.InternalSettings.get("de-settings-coauthmode") was true ???

--- a/apps/visioeditor/mobile/src/controller/Main.jsx
+++ b/apps/visioeditor/mobile/src/controller/Main.jsx
@@ -362,7 +362,7 @@ class MainController extends Component {
         this.api.Resize();
         this.api.zoomFitToPage();
 
-        this.applyLicense();
+        this.applyRestrictions();
 
         Common.Gateway.documentReady();
         f7.emit('resize');
@@ -373,7 +373,7 @@ class MainController extends Component {
         this._state.requireUserAction = false;
     }
 
-    applyLicense () {
+    applyRestrictions () {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
 

--- a/apps/visioeditor/mobile/src/controller/Main.jsx
+++ b/apps/visioeditor/mobile/src/controller/Main.jsx
@@ -33,7 +33,6 @@ class MainController extends Component {
         };
 
         this._state = {
-            licenseType: false,
             isDocModified: false,
             requireUserAction: true
         };
@@ -135,7 +134,6 @@ class MainController extends Component {
                 }
 
                 this.api.asc_registerCallback('asc_onGetEditorPermissions', onEditorPermissions);
-                this.api.asc_registerCallback('asc_onLicenseChanged', this.onLicenseChanged.bind(this));
                 this.api.asc_setDocInfo(docInfo);
                 this.api.asc_getEditorPermissions(this.editorConfig.licenseUrl, this.editorConfig.customerId);
 
@@ -153,36 +151,14 @@ class MainController extends Component {
             };
 
             const onEditorPermissions = params => {
-                const licType = params.asc_getLicenseType();
-                const { t } = this.props;
-                // const _t = t('Controller.Main', { returnObjects:true });
-               
-                if (Asc.c_oLicenseResult.Expired === licType ||
-                    Asc.c_oLicenseResult.Error === licType ||
-                    Asc.c_oLicenseResult.ExpiredTrial === licType ||
-                    Asc.c_oLicenseResult.NotBefore === licType ||
-                    Asc.c_oLicenseResult.ExpiredLimited === licType) {
-
-                    f7.dialog.create({
-                        title: Asc.c_oLicenseResult.NotBefore === licType ? t('Controller.Main.titleLicenseNotActive') : t('Controller.Main.titleLicenseExp'),
-                        text: Asc.c_oLicenseResult.NotBefore === licType ? t('Controller.Main.warnLicenseBefore') : t('Controller.Main.warnLicenseExp')
-                    }).open();
-                    if (this._isDocReady || this._isPermissionsInited) { // receive after refresh file
-                        Common.Notifications.trigger('api:disconnect');
-                    }
-                    return;
-                }
-
                 if ( this.onServerVersion(params.asc_getBuildVersion()) ) return;
                 if ( this._isDocReady || this._isPermissionsInited ) {
                     this.api.asc_LoadDocument();
                     return;
                 }
 
-                this.appOptions.canLicense = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
-
                 const storeAppOptions = this.props.storeAppOptions;
-                storeAppOptions.setPermissionOptions(this.document, licType, params, this.permissions, EditorUIController.isSupportEditFeature());
+                storeAppOptions.setPermissionOptions(this.document, params, this.permissions, EditorUIController.isSupportEditFeature());
                 this.applyMode(storeAppOptions);
 
                 this._isPermissionsInited = true;
@@ -397,29 +373,9 @@ class MainController extends Component {
         this._state.requireUserAction = false;
     }
 
-    onLicenseChanged (params) {
-        const appOptions = this.props.storeAppOptions;
-        const licType = params.asc_getLicenseType();
-        if (licType !== undefined && (appOptions.canEdit || appOptions.isRestrictedEdit) && appOptions.config.mode !== 'view' &&
-            (licType === Asc.c_oLicenseResult.Connections || licType === Asc.c_oLicenseResult.UsersCount || licType === Asc.c_oLicenseResult.ConnectionsOS || licType === Asc.c_oLicenseResult.UsersCountOS
-                || licType === Asc.c_oLicenseResult.SuccessLimit && (appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0))
-            this._state.licenseType = licType;
-
-        if (licType !== undefined && appOptions.canLiveView && (licType===Asc.c_oLicenseResult.ConnectionsLive || licType===Asc.c_oLicenseResult.ConnectionsLiveOS||
-                                                                licType===Asc.c_oLicenseResult.UsersViewCount || licType===Asc.c_oLicenseResult.UsersViewCountOS))
-            this._state.licenseType = licType;
-
-        if (this._isDocReady && this._state.licenseType)
-            this.applyLicense();
-    }
-
     applyLicense () {
         const { t } = this.props;
         const _t = t('Controller.Main', {returnObjects:true});
-
-        const warnNoLicense  = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
-        const warnNoLicenseUsers = _t.warnNoLicenseUsers.replace(/%1/g, __COMPANY_NAME__);
-        const textNoLicenseTitle = _t.textNoLicenseTitle.replace(/%1/g, __COMPANY_NAME__);
 
         const appOptions = this.props.storeAppOptions;
         if (appOptions.config.mode !== 'view' && !EditorUIController.isSupportEditFeature()) {
@@ -439,9 +395,7 @@ class MainController extends Component {
         }
 
         if (appOptions.config.mode === 'view') {
-            if (appOptions.canLiveView && (this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLive || this._state.licenseType===Asc.c_oLicenseResult.ConnectionsLiveOS ||
-                                            this._state.licenseType===Asc.c_oLicenseResult.UsersViewCount || this._state.licenseType===Asc.c_oLicenseResult.UsersViewCountOS ||
-                                            !appOptions.isAnonymousSupport && !!appOptions.config.user.anonymous)) {
+            if (!appOptions.isAnonymousSupport && !!appOptions.config.user.anonymous) {
                 appOptions.canLiveView = false;
                 this.api.asc_SetFastCollaborative(false);
             }
@@ -455,63 +409,7 @@ class MainController extends Component {
                 text : _t.warnLicenseAnonymous,
                 buttons: [{ text: _t.textOk }]
             }).open();
-        } else if (this._state.licenseType) {
-            let license = this._state.licenseType;
-            let buttons = [{ text: _t.textOk }];
-            let title = textNoLicenseTitle;
-            if ((appOptions.trialMode & Asc.c_oLicenseMode.Limited) !== 0 &&
-                (license === Asc.c_oLicenseResult.SuccessLimit ||
-                    appOptions.permissionsLicense === Asc.c_oLicenseResult.SuccessLimit)
-            ) {
-                license = _t.warnLicenseLimitedRenewed;
-            } else if (license === Asc.c_oLicenseResult.Connections || license === Asc.c_oLicenseResult.UsersCount) {
-                title = _t.titleReadOnly;
-                license = (license===Asc.c_oLicenseResult.Connections) ? _t.tipLicenseExceeded : _t.tipLicenseUsersExceeded;
-            } else {
-                license = (license === Asc.c_oLicenseResult.ConnectionsOS) ? warnNoLicense : warnNoLicenseUsers;
-                buttons = [{
-                    text: _t.textBuyNow,
-                    bold: true,
-                    onClick: function() {
-                        window.open(`${__PUBLISHER_URL__}`, "_blank");
-                    }
-                },
-                    {
-                        text: _t.textContactUs,
-                        onClick: function() {
-                            window.open(`mailto:${__SALES_EMAIL__}`, "_blank");
-                        }
-                    }];
-            }
-            if (this._state.licenseType === Asc.c_oLicenseResult.SuccessLimit) {
-                Common.Notifications.trigger('toolbar:activatecontrols');
-            } else {
-                Common.Notifications.trigger('toolbar:activatecontrols');
-                this.api.asc_coAuthoringDisconnect();
-                Common.Notifications.trigger('api:disconnect');
-            }
-
-            f7.dialog.create({
-                title: title,
-                text : license,
-                buttons: buttons
-            }).open();
         } else {
-            if (!appOptions.isDesktopApp && !appOptions.canBrandingExt &&
-                appOptions.config && appOptions.config.customization && (appOptions.config.customization.loaderName || appOptions.config.customization.loaderLogo)) {
-                f7.dialog.create({
-                    title: _t.textPaidFeature,
-                    text  : _t.textCustomLoader,
-                    buttons: [{
-                        text: _t.textContactUs,
-                        bold: true,
-                        onClick: () => {
-                            window.open(`mailto:${__SALES_EMAIL__}`, "_blank");
-                        }
-                    },
-                        { text: _t.textClose }]
-                }).open();
-            }
             Common.Notifications.trigger('toolbar:activatecontrols');
         }
     }

--- a/apps/visioeditor/mobile/src/page/main.jsx
+++ b/apps/visioeditor/mobile/src/page/main.jsx
@@ -114,7 +114,7 @@ class MainPage extends Component {
 
         if(!appOptions.isDisconnected && appOptions.isDocReady) {
             const { logo } = customization;
-            isBranding = appOptions.canBranding || appOptions.canBrandingExt;
+            isBranding = appOptions.canBrandingExt;
             
             if(logo && isBranding) {
                 isHideLogo = logo.visible === false;

--- a/apps/visioeditor/mobile/src/store/appOptions.js
+++ b/apps/visioeditor/mobile/src/store/appOptions.js
@@ -12,7 +12,6 @@ export class storeAppOptions {
             lostEditingRights: observable,
             changeEditingRights: action,
             canBrandingExt: observable,
-            canBranding: observable,
 
             isDocReady: observable,
             changeDocReady: action,
@@ -24,7 +23,6 @@ export class storeAppOptions {
     isEdit = false;
     canViewComments = false;
     canBrandingExt = true;
-    canBranding = true;
     config = {};
     customization;
 
@@ -96,12 +94,11 @@ export class storeAppOptions {
         AscCommon.UserInfoParser.setCurrentName(this.user.fullname);
     }
 
-    setPermissionOptions (document, licType, params, permissions, isSupportEditFeature) {
+    setPermissionOptions (document, params, permissions, isSupportEditFeature) {
         if (params.asc_getRights() !== Asc.c_oRights.Edit)
             permissions.edit = false;
         this.review = (permissions.review === undefined) ? (permissions.edit !== false) : permissions.review;
         this.canAnalytics = params.asc_getIsAnalyticsEnable();
-        this.canLicense = (licType === Asc.c_oLicenseResult.Success || licType === Asc.c_oLicenseResult.SuccessLimit);
         this.isLightVersion = params.asc_getIsLight();
         this.buildVersion = params.asc_getBuildVersion();
         this.canCoAuthoring = !this.isLightVersion;
@@ -110,16 +107,15 @@ export class storeAppOptions {
         this.canRequestEditRights = this.config.canRequestEditRights;
         this.canEdit = false;//(permissions.edit !== false || permissions.review === true) && // can edit or review
             // (this.config.canRequestEditRights || this.config.mode !== 'view') && // if mode=="view" -> canRequestEditRights must be defined
-            // (!this.isReviewOnly || this.canLicense) && // if isReviewOnly==true -> canLicense must be true
             // isSupportEditFeature;
-        this.isEdit = this.canLicense && this.canEdit && this.config.mode !== 'view';
-        this.canReview = this.canLicense && this.isEdit && (permissions.review===true);
-        this.canUseHistory = this.canLicense && this.config.canUseHistory && this.canCoAuthoring && !this.isDesktopApp && !this.isOffline;
+        this.isEdit = this.canEdit && this.config.mode !== 'view';
+        this.canReview = this.isEdit && (permissions.review===true);
+        this.canUseHistory = this.config.canUseHistory && this.canCoAuthoring && !this.isDesktopApp && !this.isOffline;
         this.canHistoryClose = this.config.canHistoryClose;
         this.canHistoryRestore= this.config.canHistoryRestore;
-        this.canUseMailMerge = this.canLicense && this.canEdit && !this.isDesktopApp;
-        this.canSendEmailAddresses = this.canLicense && this.config.canSendEmailAddresses && this.canEdit && this.canCoAuthoring;
-        this.canComments = false;//this.canLicense && (permissions.comment === undefined ? this.isEdit : permissions.comment) && (this.config.mode !== 'view');
+        this.canUseMailMerge = this.canEdit && !this.isDesktopApp;
+        this.canSendEmailAddresses = this.config.canSendEmailAddresses && this.canEdit && this.canCoAuthoring;
+        this.canComments = false;//(permissions.comment === undefined ? this.isEdit : permissions.comment) && (this.config.mode !== 'view');
         this.canComments = this.canComments && !((typeof (this.customization) == 'object') && this.customization.comments===false);
         this.canViewComments = false;//this.canComments || !((typeof (this.customization) == 'object') && this.customization.comments===false);
         this.canEditComments = this.isOffline || !permissions.editCommentAuthorOnly;
@@ -129,27 +125,25 @@ export class storeAppOptions {
             if (permissions.editCommentAuthorOnly===undefined && permissions.deleteCommentAuthorOnly===undefined)
                 this.canEditComments = this.canDeleteComments = this.isOffline;
         }
-        this.canChat = this.canLicense && !this.isOffline && (permissions.chat !== false);
-        this.canEditStyles = this.canLicense && this.canEdit;
+        this.canChat = !this.isOffline && (permissions.chat !== false);
+        this.canEditStyles = this.canEdit;
         this.canPrint = (permissions.print !== false);
         this.isRestrictedEdit = !this.isEdit && this.canComments && isSupportEditFeature;
-        this.trialMode = params.asc_getLicenseMode();
 
         this.canDownloadOrigin = false;
         this.canDownload = permissions.download !== false;
 
-        this.canBranding = params.asc_getCustomization();
         this.canBrandingExt = (typeof this.customization == 'object' || this.config.plugins);
 
-        this.canUseReviewPermissions = this.canLicense && (!!permissions.reviewGroups || this.customization 
+        this.canUseReviewPermissions = (!!permissions.reviewGroups || this.customization 
             && this.customization.reviewPermissions && (typeof (this.customization.reviewPermissions) == 'object'));
-        this.canUseCommentPermissions = this.canLicense && !!permissions.commentGroups;
-        this.canUseUserInfoPermissions = this.canLicense && !!permissions.userInfoGroups;
+        this.canUseCommentPermissions = !!permissions.commentGroups;
+        this.canUseUserInfoPermissions = !!permissions.userInfoGroups;
         this.canUseReviewPermissions && AscCommon.UserInfoParser.setReviewPermissions(permissions.reviewGroups, this.customization.reviewPermissions);
         this.canUseCommentPermissions && AscCommon.UserInfoParser.setCommentPermissions(permissions.commentGroups);
         this.canUseUserInfoPermissions && AscCommon.UserInfoParser.setUserInfoPermissions(permissions.userInfoGroups);
 
-        this.canLiveView = !!params.asc_getLiveViewerSupport() && (this.config.mode === 'view') && isSupportEditFeature;
+        this.canLiveView = (this.config.mode === 'view') && isSupportEditFeature;
         this.isAnonymousSupport = !!Common.EditorApi.get().asc_isAnonymousSupport();
         this.canCopy = permissions.copy !== false;
     }


### PR DESCRIPTION
Resolves #161. Resolves Euro-Office/eurooffice-nextcloud#93. Supersedes #185.

## The problem

On mobile, opening any document crashes in locales that lack the licence-warning strings — Ukrainian and Polish in particular. `applyLicense()` began with:

```js
const warnNoLicense = _t.warnNoLicense.replace(/%1/g, __COMPANY_NAME__);
```

Those three `.replace()` calls run *before* any branch, so a locale missing the string throws on every document open regardless of licence state. Presentations simply failed to open for Nextcloud users in those languages.

## The approach

#185 proposed defaulting the missing strings to their key names. That fixes the symptom but keeps a feature Euro-Office should not have: the block those strings belong to is commercial licence enforcement. It renders *"You've reached the limit for simultaneous connections to %1 editors"* with **Buy Now** → `PUBLISHER_URL` and **Contact Us** → `SALES_EMAIL`, and on the way disconnects co-authoring and deactivates the edit controls. The trigger is `ConnectionsOS` / `UsersCountOS` — the open-source-build seat cap.

Euro-Office is an AGPL fork and should never enforce anything via a licence, so this deletes the enforcement rather than papering over it. The crash and the upsell go together.

Removed across the four mobile editors, the five desktop editors, forms and the four embed viewers:

- the `_state.licenseType` branch of `applyLicense()`, including the buy-now dialog and the `asc_coAuthoringDisconnect()` / `toolbar:deactivateeditcontrols` it triggered
- `onLicenseChanged()` and its `asc_onLicenseChanged` registration
- the `Expired` / `Error` / `ExpiredTrial` / `NotBefore` / `ExpiredLimited` gate in `onEditorPermissions`, which refused to open the document at all
- the "Paid feature" custom-loader dialog — unreachable since f294a2baa6 unlocked `canBrandingExt`: it requires `!canBrandingExt` while also reading `customization.loaderName`, which cannot both hold
- `canLicense`, which was ANDed into `isEdit`, `canComments`, `canReview`, `canChat`, `canUseHistory`, `canFillForms`, `canPDFEdit` and the rest — permissions now come from the host config alone
- `canBranding` (`asc_getCustomization`), which hard-gated integrator branding, the header logo and the About customer panel
- the licence term of `canLiveView` (`asc_getLiveViewerSupport`) — a view quota, `connectionsView > 0 || usersViewCount > 0`. The capability logic is kept: `canLiveView` still requires view mode, and the co-authoring mode, `tr.live-viewer` settings row and header user count are untouched
- `permissionsLicense`, `trialMode`, the `licenseType` state fields, the `licType` parameter thread through `setPermissionOptions`, and 19 strings left unreferenced

`canBranding` and `canLiveView` were confirmed licence-derived by reading `Euro-Office/sdkjs` `common/apiBase.js:_onEndPermissions` and `Euro-Office/server` `DocService/sources/DocsCoServer.js` + `Common/sources/utils.js:1179`, rather than inferred from their names.

**Kept deliberately:** the open-source-build notice; the anonymous-access restriction, which is *not* licence-derived (`DocsCoServer.js` reads it from server config `services.CoAuthoring.server.isAnonymousSupport`, default `true`); and the LeftMenu Trial/Developer badge.

## Why this is one commit

I first split the code across two commits (enforcement, then branding/live-view). An independent review showed that boundary is not real: the enforcement branch is the *only* consumer of `permissionsLicense` and `trialMode`, the paid-feature dialog is the `else if` immediately following it in the same chain, and the branding/live-view lines sit inside the same `setPermissionOptions` bodies. Splitting by diff hunk produced commits that were individually inconsistent — one left the PE/SSE/Visio embed licence gate in place while deleting the strings it referenced. It is now one atomic commit; the mechanical locale sweep and the test-harness alignment remain separate.

## Verification

`node scripts/build-pipeline.js` equivalents run locally: all six desktop webpack configs, all four mobile builds and `deploy-embed` compile with zero errors, and `verify-bundles` / `verify-replacements` / `verify-browser-target` all pass. The existing mocha unit harness is green (12 passes, 0 failures). Grepping the built bundles confirms `canLicense`, `canBranding`, `asc_getLiveViewerSupport`, `warnNoLicense`, `textPaidFeature` and `c_oLicenseResult` are absent, while `warnLicenseAnonymous` and the Trial/Developer `c_oLicenseMode` badge survive in exactly the expected files.

This PR was also reviewed adversarially by an independent agent before submission; it caught a real regression (see below) which is fixed here.

## Known gap: no new tests

CONTRIBUTING asks for tests with every bug fix and this PR has none — flagging rather than hiding it. The crash was a dereference of a missing locale string in code this PR deletes, so there is nothing left to regression-test directly. The options I see are a guard test asserting the removed keys stay absent from the locale files, or a unit test on `setPermissionOptions` proving permissions derive from config alone. Neither fits the browser-mocha harness especially well. Happy to add either if reviewers prefer.

Note that the regression found in review — `canEdit` silently losing its `isSupportEditFeature` term — was invisible to both the build and a syntax check, because the result was still valid JavaScript. That is an argument for the `setPermissionOptions` unit test if reviewers want one.

## Stack

1. **this PR** — remove licence enforcement and gating
2. bnjamin/web-apps#4 — drop the 5723 orphaned translation keys
3. bnjamin/web-apps#3 — align the test integrator pages

Both are queued as drafts on my fork and will be retargeted here as this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)